### PR TITLE
Implement token counting & GPU metrics parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Finance leaders are sick of reconciling five-and-six-figure “mystery bills” 
 
    * Language-specific tokenisers (tiktoken, Anthropic tokenizer, BytePairLite).
    * Deterministic counting regardless of streaming or retries.
+   * Token counters for OpenAI, Anthropic and local models.
    * GPU-minute parser for local models using Nvidia DCGM metrics.
 
 3. **Usage Ledger**

--- a/src/token_tally/__init__.py
+++ b/src/token_tally/__init__.py
@@ -1,0 +1,21 @@
+"""Core TokenTally utilities."""
+
+from .token_counter import (
+    count_openai_tokens,
+    count_anthropic_tokens,
+    count_local_tokens,
+    count_tokens,
+)
+from .gpu_metrics import parse_dcgm_gpu_minutes
+from .ledger import Ledger
+from .payout import StripePayoutClient
+
+__all__ = [
+    "count_openai_tokens",
+    "count_anthropic_tokens",
+    "count_local_tokens",
+    "count_tokens",
+    "parse_dcgm_gpu_minutes",
+    "Ledger",
+    "StripePayoutClient",
+]

--- a/src/token_tally/gpu_metrics.py
+++ b/src/token_tally/gpu_metrics.py
@@ -1,0 +1,36 @@
+"""Parsing helpers for Nvidia DCGM metrics."""
+
+from __future__ import annotations
+
+import csv
+from typing import Iterable
+
+
+def parse_dcgm_gpu_minutes(lines: Iterable[str]) -> float:
+    """Return total GPU minutes from a DCGM CSV export.
+
+    The input should be an iterable of strings representing CSV rows with at
+    least ``timestamp`` and either ``gpu_util`` or ``sm_util`` columns. GPU
+    minutes are calculated as ``utilization_percent * duration`` across
+    consecutive rows.
+    """
+    reader = csv.DictReader(lines)
+    last_ts: int | None = None
+    last_util: float | None = None
+    total_util_seconds: float = 0.0
+
+    for row in reader:
+        try:
+            ts = int(row["timestamp"])
+            util = float(row.get("gpu_util", row.get("sm_util", 0)))
+        except (KeyError, ValueError):
+            continue
+        if last_ts is not None and last_util is not None:
+            dur = ts - last_ts
+            total_util_seconds += dur * (last_util / 100.0)
+        last_ts = ts
+        last_util = util
+
+    return total_util_seconds / 60.0
+
+__all__ = ["parse_dcgm_gpu_minutes"]

--- a/src/token_tally/token_counter.py
+++ b/src/token_tally/token_counter.py
@@ -1,0 +1,55 @@
+"""Token counting utilities for multiple model providers.
+
+This module avoids heavy dependencies by using simple regex-based tokenisation.
+It is not a drop-in replacement for vendor tokenisers but provides a reasonable
+approximation suitable for metering.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+_WORD_RE = re.compile(r"\w+|[^\w\s]", re.UNICODE)
+
+
+def _regex_split(text: str) -> list[str]:
+    """Split text into word-like tokens using a regex pattern."""
+    return _WORD_RE.findall(text)
+
+
+def count_openai_tokens(text: str) -> int:
+    """Approximate token count for OpenAI models."""
+    return len(_regex_split(text))
+
+
+def count_anthropic_tokens(text: str) -> int:
+    """Approximate token count for Anthropic models."""
+    return len(_regex_split(text))
+
+
+def count_local_tokens(text: str) -> int:
+    """Token count for local models using a simple whitespace split."""
+    return len(text.split())
+
+
+_PROVIDER_MAP = {
+    "openai": count_openai_tokens,
+    "anthropic": count_anthropic_tokens,
+}
+
+
+def count_tokens(provider: str, text: str) -> int:
+    """Count tokens for a given provider name.
+
+    Any unknown provider falls back to the local token counter.
+    """
+    func = _PROVIDER_MAP.get(provider.lower(), count_local_tokens)
+    return func(text)
+
+__all__ = [
+    "count_openai_tokens",
+    "count_anthropic_tokens",
+    "count_local_tokens",
+    "count_tokens",
+]

--- a/tests/test_token_counter.py
+++ b/tests/test_token_counter.py
@@ -1,0 +1,24 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import token_tally as tt
+
+
+def test_count_tokens():
+    assert tt.count_openai_tokens("hello world!") == 3
+    assert tt.count_anthropic_tokens("chatGPT") == 1
+    assert tt.count_local_tokens("one two three") == 3
+    assert tt.count_tokens("openai", "foo bar") == 2
+    assert tt.count_tokens("anthropic", "foo bar baz") == 3
+    assert tt.count_tokens("local", "a b c d") == 4
+
+
+def test_parse_dcgm_gpu_minutes():
+    lines = [
+        "timestamp,gpu_util",
+        "0,50",
+        "60,100",
+        "120,0",
+    ]
+    result = tt.parse_dcgm_gpu_minutes(lines)
+    assert abs(result - 1.5) < 1e-6
+


### PR DESCRIPTION
## Summary
- add token counters for OpenAI, Anthropic and local models
- parse GPU minutes from Nvidia DCGM CSV exports
- re-export new utilities in `token_tally.__init__`
- document new counting feature in the README
- test token counting and GPU metrics parser

## Testing
- `python -m pytest -q`
