### PR TITLE
Add usage ledger module

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Finance leaders are sick of reconciling five-and-six-figure “mystery bills” 
    * Append-only table in ClickHouse (partition by day).
    * Schema: `event_id, ts, customer_id, provider, model, metric_type, units, unit_cost_usd`.
    * Outbox stream → Kafka → Stripe Billing API nightly.
+   * Python helpers in `token_tally.usage_ledger` implement this schema and
+     emit each event to Kafka when recorded.
 
 4. **Pricing & Markup Rules**
 

--- a/src/token_tally/__init__.py
+++ b/src/token_tally/__init__.py
@@ -1,0 +1,3 @@
+from .usage_ledger import UsageEvent, UsageLedger
+
+__all__ = ["UsageEvent", "UsageLedger"]

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -1,0 +1,28 @@
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from datetime import datetime
+from token_tally import UsageEvent, UsageLedger
+
+
+def test_add_event(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    ledger = UsageLedger(db_path=str(db_path))
+    event = UsageEvent(
+        event_id="evt1",
+        ts=datetime.utcnow(),
+        customer_id="cust",
+        provider="openai",
+        model="gpt-4",
+        metric_type="tokens",
+        units=5,
+        unit_cost_usd=0.01,
+    )
+    ledger.add_event(event)
+    # Verify row saved
+    import sqlite3
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute("SELECT count(*) FROM usage_events")
+        count = cur.fetchone()[0]
+    assert count == 1


### PR DESCRIPTION
## Summary
- implement `UsageLedger` module to store usage events
- stream events to Kafka when added
- expose new helpers via package init
- test ledger insert behaviour
- document helper in README

## Testing
- `pytest -q`