### PR TITLE
Implement markup rules API, admin UI and FX conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Finance leaders are sick of reconciling five-and-six-figure “mystery bills” 
 
 4. **Pricing & Markup Rules**
 
-   * CRUD via REST + Admin UI.
+   * CRUD via REST endpoints and a simple Admin UI.
    * Versioned; effective-date field prevents silent retroactive changes.
    * Supports FX conversion with daily ECB spot rates.
 

--- a/frontend/pages/markup-rules.tsx
+++ b/frontend/pages/markup-rules.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import Navbar from '../components/Navbar'
+
+interface Rule {
+  id: string
+  provider: string
+  model: string
+  markup: number
+  effective_date: string
+}
+
+export default function MarkupRules() {
+  const [rules, setRules] = useState<Rule[]>([])
+  const [form, setForm] = useState({ provider: '', model: '', markup: '', effective_date: '' })
+
+  async function load() {
+    const res = await fetch('/markup-rules')
+    if (res.ok) setRules(await res.json())
+  }
+
+  useEffect(() => { load() }, [])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    await fetch('/markup-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: form.provider,
+        model: form.model,
+        markup: parseFloat(form.markup),
+        effective_date: form.effective_date,
+      }),
+    })
+    setForm({ provider: '', model: '', markup: '', effective_date: '' })
+    load()
+  }
+
+  async function remove(id: string) {
+    await fetch(`/markup-rules/${id}`, { method: 'DELETE' })
+    load()
+  }
+
+  return (
+    <>
+      <Navbar />
+      <main className="container mx-auto px-4 py-8">
+        <h2 className="text-2xl font-bold mb-4">Markup Rules</h2>
+        <form onSubmit={handleSubmit} className="space-x-2 mb-4">
+          <input className="border p-1" placeholder="Provider" value={form.provider} onChange={e => setForm({ ...form, provider: e.target.value })} />
+          <input className="border p-1" placeholder="Model" value={form.model} onChange={e => setForm({ ...form, model: e.target.value })} />
+          <input className="border p-1" placeholder="Markup" value={form.markup} onChange={e => setForm({ ...form, markup: e.target.value })} />
+          <input className="border p-1" placeholder="Effective" value={form.effective_date} onChange={e => setForm({ ...form, effective_date: e.target.value })} />
+          <button className="bg-blue-600 text-white px-2 py-1 rounded" type="submit">Add</button>
+        </form>
+        <ul className="space-y-2">
+          {rules.map(r => (
+            <li key={r.id} className="p-2 bg-white rounded shadow flex justify-between">
+              <span>{r.provider} {r.model} {r.markup}</span>
+              <button className="text-red-600" onClick={() => remove(r.id)}>Delete</button>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </>
+  )
+}

--- a/src/token_tally/fx.py
+++ b/src/token_tally/fx.py
@@ -1,0 +1,37 @@
+import urllib.request
+from xml.etree import ElementTree
+
+ECB_URL = "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
+
+
+def parse_ecb_rates(xml_data: bytes) -> dict:
+    """Parse ECB FX XML into a currency->rate mapping (EUR base)."""
+    tree = ElementTree.fromstring(xml_data)
+    ns = {
+        "gesmes": "http://www.gesmes.org/xml/2002-08-01",
+        "ecb": "http://www.ecb.int/vocabulary/2002-08-01/eurofxref",
+    }
+    cube = tree.find(".//ecb:Cube/ecb:Cube", ns)
+    rates = {"EUR": 1.0}
+    if cube is not None:
+        for child in cube:
+            cur = child.attrib.get("currency")
+            rate = child.attrib.get("rate")
+            if cur and rate:
+                rates[cur] = float(rate)
+    return rates
+
+
+def get_ecb_rates() -> dict:
+    """Fetch the latest FX rates from ECB."""
+    with urllib.request.urlopen(ECB_URL) as resp:
+        data = resp.read()
+    return parse_ecb_rates(data)
+
+
+def convert(amount: float, from_cur: str, to_cur: str, rates: dict) -> float:
+    """Convert an amount between currencies using EUR-based rates."""
+    if from_cur not in rates or to_cur not in rates:
+        raise ValueError("Missing currency rate")
+    eur = amount / rates[from_cur]
+    return eur * rates[to_cur]

--- a/src/token_tally/server.py
+++ b/src/token_tally/server.py
@@ -1,0 +1,80 @@
+import json
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse
+
+from .markup import MarkupRuleStore
+
+store = MarkupRuleStore()
+
+
+class MarkupHandler(BaseHTTPRequestHandler):
+    def _send_json(self, data, status=200):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == "/markup-rules":
+            self._send_json(store.list_rules())
+        elif path.startswith("/markup-rules/"):
+            rule_id = path.split("/")[-1]
+            rule = store.get_rule(rule_id)
+            if rule:
+                self._send_json(rule)
+            else:
+                self._send_json({"error": "not found"}, 404)
+        else:
+            self._send_json({"error": "not found"}, 404)
+
+    def do_POST(self):
+        path = urlparse(self.path).path
+        if path != "/markup-rules":
+            self._send_json({"error": "not found"}, 404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length)) if length else {}
+        rule_id = body.get("id") or str(uuid.uuid4())
+        provider = body.get("provider")
+        model = body.get("model")
+        markup = body.get("markup")
+        effective_date = body.get("effective_date")
+        if not all([provider, model, markup, effective_date]):
+            self._send_json({"error": "invalid body"}, 400)
+            return
+        store.create_rule(rule_id, provider, model, float(markup), effective_date)
+        self._send_json({"id": rule_id})
+
+    def do_PUT(self):
+        path = urlparse(self.path).path
+        if not path.startswith("/markup-rules/"):
+            self._send_json({"error": "not found"}, 404)
+            return
+        rule_id = path.split("/")[-1]
+        length = int(self.headers.get("Content-Length", "0"))
+        updates = json.loads(self.rfile.read(length)) if length else {}
+        store.update_rule(rule_id, **updates)
+        self._send_json({"status": "ok"})
+
+    def do_DELETE(self):
+        path = urlparse(self.path).path
+        if not path.startswith("/markup-rules/"):
+            self._send_json({"error": "not found"}, 404)
+            return
+        rule_id = path.split("/")[-1]
+        store.delete_rule(rule_id)
+        self._send_json({"status": "deleted"})
+
+
+def run(host: str = "0.0.0.0", port: int = 8000):
+    server = HTTPServer((host, port), MarkupHandler)
+    print(f"Markup server running on {host}:{port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_markup_fx.py
+++ b/tests/test_markup_fx.py
@@ -1,0 +1,37 @@
+import pathlib
+import sys
+
+BASE_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(BASE_DIR / "src"))
+
+from token_tally.markup import MarkupRuleStore  # noqa: E402
+from token_tally.fx import parse_ecb_rates, convert  # noqa: E402
+
+
+def test_markup_rule_crud(tmp_path):
+    db = tmp_path / "rules.db"
+    store = MarkupRuleStore(str(db))
+    store.create_rule("1", "openai", "gpt-4o", 0.2, "2025-01-01")
+    rule = store.get_rule("1")
+    assert rule["provider"] == "openai"
+    store.update_rule("1", markup=0.3)
+    assert store.get_rule("1")["markup"] == 0.3
+    assert len(store.list_rules()) == 1
+    store.delete_rule("1")
+    assert store.get_rule("1") is None
+
+
+def test_parse_rates_and_convert():
+    xml = b"""<?xml version='1.0' encoding='UTF-8'?>\n"""
+    xml += (
+        b"<gesmes:Envelope xmlns:gesmes='http://www.gesmes.org/xml/2002-08-01' "
+        b"xmlns='http://www.ecb.int/vocabulary/2002-08-01/eurofxref'>"
+        b"<Cube><Cube time='2024-05-31'>"
+        b"<Cube currency='USD' rate='1.1'/><Cube currency='GBP' rate='0.9'/>"
+        b"</Cube></Cube></gesmes:Envelope>"
+    )
+    rates = parse_ecb_rates(xml)
+    assert rates["USD"] == 1.1
+    amount_gbp = convert(1.0, "USD", "GBP", rates)
+    expected = 1.0 / 1.1 * 0.9
+    assert round(amount_gbp, 6) == round(expected, 6)


### PR DESCRIPTION
## Summary
- flesh out Pricing & Markup Rules section in README
- add a simple SQLite-backed markup rule store
- expose HTTP CRUD endpoints for markup rules
- add ECB FX utilities
- add an admin page for managing markup rules
- cover markup rules and FX helpers with tests

## Testing
- `ruff check src tests`
- `black --check src tests`
- `pytest -q`
