### PR TITLE
Add basic forecasting and credit limit enforcement

### DIFF
--- a/gateway-worker/src/index.ts
+++ b/gateway-worker/src/index.ts
@@ -1,4 +1,7 @@
-export interface Env {}
+export interface Env {
+  CREDIT_LIMIT?: string;
+  WEBHOOK_URL?: string;
+}
 
 const PROVIDER_BASE: Record<string, string> = {
   openai: 'https://api.openai.com',
@@ -12,6 +15,8 @@ const WINDOW_MS = 60_000;
 const concurrency = new Map<string, number>();
 interface Bucket { tokens: number; last: number; }
 const buckets = new Map<string, Bucket>();
+const spendTotals = new Map<string, number>();
+const alerted = new Set<string>();
 
 function enterConcurrency(key: string): boolean {
   const current = concurrency.get(key) || 0;
@@ -40,8 +45,17 @@ function allowRequest(key: string): boolean {
   return true;
 }
 
+async function sendAlert(env: Env, msg: string): Promise<void> {
+  if (!env.WEBHOOK_URL) return;
+  await fetch(env.WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: msg }),
+  });
+}
+
 export default {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(request: Request, env: Env): Promise<Response> {
     const apiKey = request.headers.get('Authorization');
     if (!apiKey) {
       return new Response('Missing Authorization header', { status: 401 });
@@ -62,6 +76,14 @@ export default {
       return new Response('Unknown provider', { status: 400 });
     }
 
+    const creditLimit = parseFloat(env.CREDIT_LIMIT || '0');
+    const spent = spendTotals.get(apiKey) || 0;
+    if (creditLimit > 0 && spent >= creditLimit) {
+      await sendAlert(env, `API key ${apiKey} exceeded credit limit`);
+      exitConcurrency(apiKey);
+      return new Response('Credit limit exceeded', { status: 429 });
+    }
+
     const url = new URL(request.url);
     const targetUrl = base + url.pathname + url.search;
     const proxyReq = new Request(targetUrl, request);
@@ -69,6 +91,15 @@ export default {
 
     try {
       const resp = await fetch(proxyReq);
+      const cost = parseFloat(resp.headers.get('X-Usage-Cost') || '0');
+      if (creditLimit > 0 && cost > 0) {
+        const newTotal = spent + cost;
+        spendTotals.set(apiKey, newTotal);
+        if (newTotal >= creditLimit && !alerted.has(apiKey)) {
+          alerted.add(apiKey);
+          await sendAlert(env, `API key ${apiKey} hit credit limit`);
+        }
+      }
       return resp;
     } finally {
       exitConcurrency(apiKey);

--- a/src/token_tally/__init__.py
+++ b/src/token_tally/__init__.py
@@ -1,7 +1,4 @@
 from .usage_ledger import UsageEvent, UsageLedger
-
-__all__ = ["UsageEvent", "UsageLedger"]
-
 from .token_counter import (
     count_openai_tokens,
     count_anthropic_tokens,
@@ -11,8 +8,12 @@ from .token_counter import (
 from .gpu_metrics import parse_dcgm_gpu_minutes
 from .ledger import Ledger
 from .payout import StripePayoutClient
+from .forecast import arima_forecast, forecast_next_hour
+from .alerts import send_webhook_message
 
 __all__ = [
+    "UsageEvent",
+    "UsageLedger",
     "count_openai_tokens",
     "count_anthropic_tokens",
     "count_local_tokens",
@@ -20,4 +21,7 @@ __all__ = [
     "parse_dcgm_gpu_minutes",
     "Ledger",
     "StripePayoutClient",
+    "arima_forecast",
+    "forecast_next_hour",
+    "send_webhook_message",
 ]

--- a/src/token_tally/alerts.py
+++ b/src/token_tally/alerts.py
@@ -1,0 +1,15 @@
+"""Utility functions for sending webhook alerts."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+
+
+def send_webhook_message(url: str, message: str) -> None:
+    """POST a simple JSON payload to the given webhook URL."""
+    data = json.dumps({"text": message}).encode()
+    req = urllib.request.Request(url, data=data)
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req) as resp:  # pragma: no cover - network
+        resp.read()

--- a/src/token_tally/forecast.py
+++ b/src/token_tally/forecast.py
@@ -1,0 +1,38 @@
+"""Lightweight hourly spend forecasting using a simple ARIMA(1,1,0) model."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import List
+
+from .usage_ledger import UsageLedger
+
+
+def arima_forecast(series: List[float]) -> float:
+    """Forecast the next value for a univariate series.
+
+    This minimal implementation fits an ARIMA(1,1,0) model using
+    ordinary least squares. It falls back to a naive diff if the
+    series has constant differences.
+    """
+    if not series:
+        raise ValueError("series must not be empty")
+    if len(series) < 2:
+        return series[-1]
+
+    diffs = [series[i] - series[i - 1] for i in range(1, len(series))]
+    if len(set(diffs)) == 1:
+        return series[-1] + diffs[-1]
+
+    mean = sum(diffs[:-1]) / max(len(diffs) - 1, 1)
+    num = sum((diffs[i] - mean) * (diffs[i - 1] - mean) for i in range(1, len(diffs)))
+    den = sum((diffs[i - 1] - mean) ** 2 for i in range(1, len(diffs)))
+    phi = num / den if den else 0.0
+    forecast_diff = mean + phi * (diffs[-1] - mean)
+    return series[-1] + forecast_diff
+
+
+def forecast_next_hour(ledger: UsageLedger, hours: int = 24) -> float:
+    """Return the forecasted spend for the next hour."""
+    totals = ledger.get_hourly_totals(hours)
+    return arima_forecast(totals)

--- a/src/token_tally/tests/test_alerts.py
+++ b/src/token_tally/tests/test_alerts.py
@@ -1,0 +1,33 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+import types
+
+from token_tally.alerts import send_webhook_message
+
+
+class DummyResp:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def read(self):
+        return b"ok"
+
+
+def test_send_webhook_message(monkeypatch):
+    called = {}
+
+    def fake_urlopen(req):
+        called["url"] = req.full_url
+        called["data"] = req.data
+        return DummyResp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    send_webhook_message("http://example.com", "hi")
+    assert called["url"] == "http://example.com"
+    assert b"hi" in called["data"]

--- a/src/token_tally/tests/test_forecast.py
+++ b/src/token_tally/tests/test_forecast.py
@@ -1,0 +1,32 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from datetime import datetime, timedelta
+
+from token_tally import UsageLedger, UsageEvent, arima_forecast, forecast_next_hour
+
+
+def test_arima_constant():
+    assert arima_forecast([1, 2, 3, 4]) == 5
+
+
+def test_hourly_totals_and_forecast(tmp_path):
+    db = tmp_path / "ledger.db"
+    ledger = UsageLedger(db_path=str(db))
+    now = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+    for i in range(3):
+        event = UsageEvent(
+            event_id=f"e{i}",
+            ts=now - timedelta(hours=3 - i),
+            customer_id="cust",
+            provider="openai",
+            model="gpt",
+            metric_type="tokens",
+            units=10,
+            unit_cost_usd=0.5,
+        )
+        ledger.add_event(event)
+    totals = ledger.get_hourly_totals(4)
+    forecast = forecast_next_hour(ledger, hours=4)
+    assert forecast > 0


### PR DESCRIPTION
## Summary
- implement lightweight ARIMA(1,1,0) forecaster
- support hourly spend totals in `UsageLedger`
- expose webhook utility and tests
- enforce credit limit and send alerts in gateway worker
- add tests for new modules

## Testing
- `pytest -q`
