### PR TITLE
Add compliance roadmap and Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ Finance leaders are sick of reconciling five-and-six-figure “mystery bills” 
 
 9. **Compliance Pack**
 
-   * SOC 2 Type I within 9 months; Type II within 18 months.
-   * Data residency: option to pin entire pipeline to EU region.
-   * Private-cloud (Helm chart) for Enterprise tier.
+   * SOC 2 roadmap published; see "SOC 2 & Data Residency" below.
+   * Data residency: US or EU-managed clusters, or self-host via Helm.
+   * Private-cloud (Helm chart) for Enterprise tier (see `helm/token-tally`).
 
 ---
 
@@ -222,6 +222,21 @@ Stripe Invoice → Customer
 
 ---
 **Bottom line:** This gateway solves a *real*, boring accounting problem nobody wants to touch. Nail deterministic metering, stay invisible in the hot path, and invoice cleanly—everything else is a feature-creep distraction.
+
+## SOC 2 & Data Residency
+
+### SOC 2 roadmap
+
+| Milestone                     | Target    |
+| ----------------------------- | --------- |
+| Policies & risk assessment    | Aug 2025  |
+| Type I audit                  | Q1 2026   |
+| Continuous monitoring in place| Q2 2026   |
+| Type II report                | Q4 2026   |
+
+### Data residency options
+
+TokenTally runs in US-East by default. Enterprise customers may pin all data processing to the EU region or deploy the gateway inside their own Kubernetes clusters using the Helm chart under `helm/token-tally`.
 
 ## Frontend
 A simple Next.js + Tailwind admin portal lives in `frontend/`. Run `npm install` inside that folder and `npm run dev` to start it locally. The app lets you manage API keys and view usage reports via calls to `NEXT_PUBLIC_BACKEND_URL`.

--- a/helm/token-tally/Chart.yaml
+++ b/helm/token-tally/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: token-tally
+description: TokenTally private cloud deployment
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/helm/token-tally/README.md
+++ b/helm/token-tally/README.md
@@ -1,0 +1,18 @@
+# TokenTally Helm Chart
+
+This chart deploys the TokenTally gateway and billing server in a private Kubernetes cluster.
+
+```bash
+helm repo add tokentally https://example.com/charts
+helm install my-tally tokentally/token-tally
+```
+
+Values can be overridden via `--set` or a custom `values.yaml`:
+
+```yaml
+image:
+  repository: ghcr.io/tokentally/server
+  tag: latest
+service:
+  type: LoadBalancer
+```

--- a/helm/token-tally/templates/_helpers.tpl
+++ b/helm/token-tally/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "token-tally.name" -}}
+{{ include "chart.name" . }}
+{{- end -}}
+
+{{- define "token-tally.fullname" -}}
+{{ include "chart.name" . }}-{{ .Release.Name }}
+{{- end -}}

--- a/helm/token-tally/templates/deployment.yaml
+++ b/helm/token-tally/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "token-tally.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "token-tally.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "token-tally.name" . }}
+    spec:
+      containers:
+        - name: server
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/helm/token-tally/templates/service.yaml
+++ b/helm/token-tally/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "token-tally.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ include "token-tally.name" . }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/helm/token-tally/values.yaml
+++ b/helm/token-tally/values.yaml
@@ -1,0 +1,10 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/tokentally/server
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8000


### PR DESCRIPTION
## Summary
- document SOC 2 schedule and data-residency choices
- mention Helm chart location in compliance section
- add Helm chart for private-cloud Kubernetes installs

## Testing
- `pytest -q`
