### PR TITLE
Add FX rate storage and billing conversion

### DIFF
--- a/src/token_tally/fx_rates.py
+++ b/src/token_tally/fx_rates.py
@@ -1,0 +1,75 @@
+import sqlite3
+from datetime import date
+from typing import Dict, Optional
+
+from .fx import get_ecb_rates
+
+DB_PATH = "fx_rates.db"
+
+
+def _ensure_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS fx_rates (
+            date TEXT NOT NULL,
+            currency TEXT NOT NULL,
+            rate REAL NOT NULL,
+            PRIMARY KEY (date, currency)
+        )
+        """
+    )
+
+
+def store_rates(
+    rates: Dict[str, float], fetch_date: Optional[str] = None, db_path: str = DB_PATH
+) -> str:
+    """Persist a mapping of currency rates for a given date."""
+    fetch_date = fetch_date or date.today().isoformat()
+    with sqlite3.connect(db_path) as conn:
+        _ensure_table(conn)
+        for cur, rate in rates.items():
+            conn.execute(
+                "INSERT OR REPLACE INTO fx_rates (date, currency, rate) VALUES (?, ?, ?)",
+                (fetch_date, cur, rate),
+            )
+        conn.commit()
+    return fetch_date
+
+
+def fetch_and_store(db_path: str = DB_PATH) -> str:
+    """Fetch latest ECB rates and store them."""
+    rates = get_ecb_rates()
+    return store_rates(rates, db_path=db_path)
+
+
+def get_rates(
+    fetch_date: Optional[str] = None, db_path: str = DB_PATH
+) -> Dict[str, float]:
+    """Load rates for the specified date or the most recent available."""
+    with sqlite3.connect(db_path) as conn:
+        _ensure_table(conn)
+        if fetch_date is None:
+            cur = conn.execute("SELECT MAX(date) FROM fx_rates")
+            row = cur.fetchone()
+            fetch_date = row[0] if row and row[0] else None
+            if fetch_date is None:
+                return {}
+        cur = conn.execute(
+            "SELECT currency, rate FROM fx_rates WHERE date = ?", (fetch_date,)
+        )
+        return {cur: rate for cur, rate in cur.fetchall()}
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    argv = argv or []
+    if argv and argv[0] == "fetch":
+        fetch_date = fetch_and_store()
+        print(f"Stored FX rates for {fetch_date}")
+    else:
+        print("Usage: python -m token_tally.fx_rates fetch")
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv[1:])

--- a/src/token_tally/tests/test_billing.py
+++ b/src/token_tally/tests/test_billing.py
@@ -1,14 +1,18 @@
 import sys, pathlib
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 from token_tally.billing import BillingService, StripeUsageClient
 from token_tally.ledger import Ledger
 
+
 class DummyClient(StripeUsageClient):
     def __init__(self):
         pass
+
     def create_usage_record(self, subscription_item, quantity, timestamp):
         return {"id": f"usage-{subscription_item}-{quantity}"}
+
 
 def test_sync_usage_events(tmp_path):
     db = tmp_path / "ledger.db"
@@ -21,6 +25,7 @@ def test_sync_usage_events(tmp_path):
     events = ledger.get_pending_usage_events()
     assert events == []
 
+
 def test_consolidate_invoices(tmp_path):
     db = tmp_path / "ledger.db"
     ledger = Ledger(str(db))
@@ -31,3 +36,17 @@ def test_consolidate_invoices(tmp_path):
     invoices = service.consolidate_invoices("2024-05")
     assert invoices == [{"invoice_id": "cust-2024-05", "total": 20.0, "credit": 4.0}]
 
+
+def test_consolidate_invoices_fx(tmp_path, monkeypatch):
+    db = tmp_path / "ledger.db"
+    ledger = Ledger(str(db))
+    ledger.add_usage_event("e1", "cust", "item1", 10, 2.0, "2024-05")
+    service = BillingService("sk_test", ledger)
+    service.client = DummyClient()
+
+    monkeypatch.setattr(
+        "token_tally.billing.get_rates",
+        lambda: {"USD": 1.0, "EUR": 0.9},
+    )
+    invoices = service.consolidate_invoices("2024-05", currency="EUR")
+    assert invoices == [{"invoice_id": "cust-2024-05", "total": 18.0, "credit": 0.0}]

--- a/tests/test_fx_rates.py
+++ b/tests/test_fx_rates.py
@@ -1,0 +1,30 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from token_tally.fx import parse_ecb_rates, convert
+from token_tally.fx_rates import store_rates, get_rates
+
+
+def test_parse_ecb_rates():
+    xml = (
+        b"<?xml version='1.0' encoding='UTF-8'?>"
+        b"<gesmes:Envelope xmlns:gesmes='http://www.gesmes.org/xml/2002-08-01' "
+        b"xmlns='http://www.ecb.int/vocabulary/2002-08-01/eurofxref'>"
+        b"<Cube><Cube time='2024-05-31'>"
+        b"<Cube currency='USD' rate='1.1'/><Cube currency='GBP' rate='0.9'/>"
+        b"</Cube></Cube></gesmes:Envelope>"
+    )
+    rates = parse_ecb_rates(xml)
+    assert rates["USD"] == 1.1
+    amount = convert(1.0, "USD", "GBP", rates)
+    expected = 1.0 / 1.1 * 0.9
+    assert round(amount, 6) == round(expected, 6)
+
+
+def test_store_and_get_rates(tmp_path):
+    db = tmp_path / "fx.db"
+    store_rates({"USD": 1.1, "EUR": 1.0}, db_path=str(db), fetch_date="2024-05-31")
+    rates = get_rates(db_path=str(db))
+    assert rates["USD"] == 1.1


### PR DESCRIPTION
## Summary
- store daily ECB FX rates in sqlite database
- add CLI to fetch and persist rates
- read stored rates when consolidating invoices
- test FX rate storage and currency conversion logic

## Testing
- `pytest -q`
- `npm run build` *(fails: `next` not found)*