### PR TITLE
Implement audit log hash chain

### DIFF
--- a/src/token_tally/audit.py
+++ b/src/token_tally/audit.py
@@ -32,7 +32,8 @@ class AuditLog:
                     ts TEXT NOT NULL,
                     customer_id TEXT NOT NULL,
                     prompt_hash TEXT NOT NULL,
-                    token_count INTEGER NOT NULL
+                    token_count INTEGER NOT NULL,
+                    prev_hash TEXT
                 )
                 """
             )
@@ -49,24 +50,69 @@ class AuditLog:
         ts = ts or datetime.utcnow()
         prompt_hash = sha256(prompt.encode("utf-8")).hexdigest()
         with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute(
+                "SELECT prev_hash FROM audit_events WHERE customer_id = ? ORDER BY ts DESC LIMIT 1",
+                (customer_id,),
+            )
+            row = cur.fetchone()
+            last_hash = row[0] if row else ""
+            chain_hash = sha256((last_hash + prompt_hash).encode("utf-8")).hexdigest()
             conn.execute(
                 """
                 INSERT OR REPLACE INTO audit_events (
-                    event_id, ts, customer_id, prompt_hash, token_count
-                ) VALUES (?, ?, ?, ?, ?)
+                    event_id, ts, customer_id, prompt_hash, token_count, prev_hash
+                ) VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (event_id, ts.isoformat(), customer_id, prompt_hash, token_count),
+                (
+                    event_id,
+                    ts.isoformat(),
+                    customer_id,
+                    prompt_hash,
+                    token_count,
+                    chain_hash,
+                ),
             )
             conn.commit()
 
     def list_events(self, customer_id: Optional[str] = None) -> List[Dict[str, any]]:
-        query = "SELECT event_id, ts, customer_id, prompt_hash, token_count FROM audit_events"
+        query = "SELECT event_id, ts, customer_id, prompt_hash, token_count, prev_hash FROM audit_events"
         params: tuple[str, ...] = ()
         if customer_id:
             query += " WHERE customer_id = ?"
             params = (customer_id,)
+        query += " ORDER BY ts"
         with sqlite3.connect(self.db_path) as conn:
             cur = conn.execute(query, params)
             rows = cur.fetchall()
-        keys = ["event_id", "ts", "customer_id", "prompt_hash", "token_count"]
+        keys = [
+            "event_id",
+            "ts",
+            "customer_id",
+            "prompt_hash",
+            "token_count",
+            "prev_hash",
+        ]
         return [dict(zip(keys, row)) for row in rows]
+
+    def verify_chain(self, customer_id: Optional[str] = None) -> bool:
+        """Return ``True`` if the hash chain is intact."""
+        customers: List[str]
+        with sqlite3.connect(self.db_path) as conn:
+            if customer_id:
+                customers = [customer_id]
+            else:
+                cur = conn.execute("SELECT DISTINCT customer_id FROM audit_events")
+                customers = [row[0] for row in cur.fetchall()]
+            for cust in customers:
+                cur = conn.execute(
+                    "SELECT prompt_hash, prev_hash FROM audit_events WHERE customer_id = ? ORDER BY ts",
+                    (cust,),
+                )
+                rows = cur.fetchall()
+                prev = ""
+                for prompt_hash, stored_hash in rows:
+                    expected = sha256((prev + prompt_hash).encode("utf-8")).hexdigest()
+                    if stored_hash != expected:
+                        return False
+                    prev = stored_hash
+        return True

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -4,6 +4,8 @@ import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from datetime import datetime
+from hashlib import sha256
+import sqlite3
 from token_tally.audit import AuditLog
 
 
@@ -16,3 +18,21 @@ def test_add_and_list(tmp_path):
     assert events[0]["event_id"] == "evt1"
     assert events[0]["customer_id"] == "cust"
     assert events[0]["token_count"] == 5
+    expected_hash = sha256(("" + events[0]["prompt_hash"]).encode("utf-8")).hexdigest()
+    assert events[0]["prev_hash"] == expected_hash
+
+
+def test_hash_chain_verification(tmp_path):
+    db_path = tmp_path / "audit.db"
+    log = AuditLog(str(db_path))
+    log.add_event("evt1", "cust", "hello", 1, datetime(2024, 1, 1))
+    log.add_event("evt2", "cust", "world", 2, datetime(2024, 1, 2))
+    assert log.verify_chain("cust")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE audit_events SET prev_hash = 'bad' WHERE event_id = 'evt2'"
+        )
+        conn.commit()
+
+    assert not log.verify_chain("cust")


### PR DESCRIPTION
## Summary
- extend audit log with `prev_hash` column
- link events by computing sha256(prev + current)
- add chain verification API
- cover event hashing and verification in tests

## Testing
- `pytest -q`
- `npm run build` *(fails: `next` not found)*