### PR TITLE
Add conditional NextAuth providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,14 @@ TokenTally runs in US-East by default. Enterprise customers may pin all data pro
 ## Frontend
 A Next.js + tRPC admin portal lives in `frontend/`. Run `npm install` in that
 folder and `npm run dev` to start it locally. The portal uses NextAuth for SSO
-(Google or any SAML 2.0 provider). It exposes tRPC endpoints for usage data and
-an audit log, shown in the Usage and Audit sections of the UI.
+(Google or any SAML 2.0 provider). Set the following variables to enable each
+provider:
+
+- `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` – Google sign-in
+- `SAML_ENTRYPOINT`, `SAML_ISSUER` and `SAML_CERT` – generic SAML provider
+
+The frontend exposes tRPC endpoints for usage data and an audit log, shown in
+the Usage and Audit sections of the UI.
 
 ## Client SDKs
 Lightweight SDK wrappers live in `clients/` for TypeScript, Python and Go. Each

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,12 @@
+# TokenTally Frontend
+
+This folder contains the Next.js admin portal. Install dependencies with `npm install` and start the dev server with `npm run dev`.
+
+## Authentication providers
+
+NextAuth is configured in `pages/api/auth/[...nextauth].ts`. The credentials provider is always enabled. Google and SAML providers are added if the following environment variables are present:
+
+- `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` – enable Google sign-in.
+- `SAML_ENTRYPOINT`, `SAML_ISSUER` and `SAML_CERT` – enable a generic SAML 2.0 provider.
+
+If the variables are not set the corresponding provider is skipped.

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -1,20 +1,47 @@
 import NextAuth from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
+import GoogleProvider from 'next-auth/providers/google'
+import SAMLProvider from 'next-auth/providers/saml'
+
+const providers = [
+  CredentialsProvider({
+    name: 'Credentials',
+    credentials: {
+      email: { label: 'Email', type: 'text' },
+      password: { label: 'Password', type: 'password' },
+    },
+    authorize: async (credentials) => {
+      if (credentials?.email && credentials.password) {
+        return { id: credentials.email, email: credentials.email }
+      }
+      return null
+    },
+  }),
+]
+
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  providers.push(
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    })
+  )
+}
+
+if (
+  process.env.SAML_ENTRYPOINT &&
+  process.env.SAML_ISSUER &&
+  process.env.SAML_CERT
+) {
+  providers.push(
+    SAMLProvider({
+      entryPoint: process.env.SAML_ENTRYPOINT,
+      issuer: process.env.SAML_ISSUER,
+      cert: process.env.SAML_CERT,
+    })
+  )
+}
 
 export default NextAuth({
-  providers: [
-    CredentialsProvider({
-      name: 'Credentials',
-      credentials: {
-        email: { label: 'Email', type: 'text' },
-        password: { label: 'Password', type: 'password' },
-      },
-      authorize: async (credentials) => {
-        if (credentials?.email && credentials.password) {
-          return { id: credentials.email, email: credentials.email }
-        }
-        return null
-      },
-    }),
-  ],
+  providers,
 })

--- a/tests/load_nextauth.mjs
+++ b/tests/load_nextauth.mjs
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import vm from 'vm';
+import path from 'path';
+
+const file = path.resolve(process.argv[2]);
+const code = fs.readFileSync(file, 'utf8');
+const context = vm.createContext({ console, process: { env: { ...process.env } } });
+const mod = new vm.SourceTextModule(code, { context, identifier: file });
+
+const linker = async (specifier) => {
+  if (specifier === 'next-auth') {
+    return new vm.SourceTextModule('export default (o) => o;', { context });
+  }
+  if (specifier === 'next-auth/providers/credentials') {
+    return new vm.SourceTextModule('export default (o) => ({ id: "credentials", opts: o });', { context });
+  }
+  if (specifier === 'next-auth/providers/google') {
+    return new vm.SourceTextModule('export default (o) => ({ id: "google", opts: o });', { context });
+  }
+  if (specifier === 'next-auth/providers/saml') {
+    return new vm.SourceTextModule('export default (o) => ({ id: "saml", opts: o });', { context });
+  }
+  throw new Error('Unknown module ' + specifier);
+};
+
+await mod.link(linker);
+await mod.evaluate();
+console.log(JSON.stringify(mod.namespace.default));
+

--- a/tests/test_nextauth_config.py
+++ b/tests/test_nextauth_config.py
@@ -1,0 +1,41 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOADER = ROOT / "tests" / "load_nextauth.mjs"
+CONFIG = ROOT / "frontend" / "pages" / "api" / "auth" / "[...nextauth].ts"
+
+
+def load_config(extra_env=None):
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(
+        ["node", "--experimental-vm-modules", LOADER, str(CONFIG)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_load_default():
+    cfg = load_config()
+    assert any(p["id"] == "credentials" for p in cfg["providers"])
+
+
+def test_load_google():
+    cfg = load_config({"GOOGLE_CLIENT_ID": "id", "GOOGLE_CLIENT_SECRET": "sec"})
+    ids = [p["id"] for p in cfg["providers"]]
+    assert "google" in ids
+
+
+def test_load_saml():
+    cfg = load_config(
+        {"SAML_ENTRYPOINT": "url", "SAML_ISSUER": "iss", "SAML_CERT": "cert"}
+    )
+    ids = [p["id"] for p in cfg["providers"]]
+    assert "saml" in ids


### PR DESCRIPTION
## Summary
- add Google and SAML providers when env vars are set
- document auth provider environment variables
- include frontend README
- add tests ensuring provider config loads

## Testing
- `pytest -q`