### PR TITLE
Fix datetime deprecation

### DIFF
--- a/src/token_tally/audit.py
+++ b/src/token_tally/audit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, UTC
 from hashlib import sha256
 from typing import List, Optional, Dict
 
@@ -47,7 +47,7 @@ class AuditLog:
         token_count: int,
         ts: Optional[datetime] = None,
     ) -> None:
-        ts = ts or datetime.utcnow()
+        ts = ts or datetime.now(UTC)
         prompt_hash = sha256(prompt.encode("utf-8")).hexdigest()
         with sqlite3.connect(self.db_path) as conn:
             cur = conn.execute(

--- a/src/token_tally/budget_alert.py
+++ b/src/token_tally/budget_alert.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Optional, Dict
 
 from .ledger import Ledger
@@ -11,7 +11,7 @@ from .alerts import send_webhook_message
 def run(db_path: str, webhook_url: str, cycle: Optional[str] = None) -> None:
     """Check spend against monthly budgets and send alerts."""
     ledger = Ledger(db_path)
-    cycle = cycle or datetime.utcnow().strftime("%Y-%m")
+    cycle = cycle or datetime.now(UTC).strftime("%Y-%m")
 
     events = ledger.get_usage_events_by_cycle(cycle)
     spend: Dict[str, float] = {}

--- a/src/token_tally/ledger.py
+++ b/src/token_tally/ledger.py
@@ -1,10 +1,9 @@
 import sqlite3
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Optional, Dict, Any
 
 from . import fx
 from . import markup
-
 
 
 class Ledger:
@@ -144,7 +143,7 @@ class Ledger:
         ts: Optional[datetime] = None,
         markup_db_path: Optional[str] = None,
     ) -> None:
-        ts = ts or datetime.utcnow()
+        ts = ts or datetime.now(UTC)
         markup_rule = None
         if provider and model:
             rule = markup.get_effective_markup(
@@ -206,7 +205,6 @@ class Ledger:
             )
             keys = ["customer_id", "units", "unit_cost"]
             return [dict(zip(keys, row)) for row in cur.fetchall()]
-
 
     def get_usage_events_by_range(self, start: str, end: str):
         """Return usage events between ``start`` and ``end`` dates (inclusive)."""

--- a/src/token_tally/tests/test_forecast.py
+++ b/src/token_tally/tests/test_forecast.py
@@ -2,7 +2,7 @@ import sys
 import pathlib
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 from token_tally import UsageLedger, UsageEvent, arima_forecast, forecast_next_hour
 
@@ -14,7 +14,7 @@ def test_arima_constant():
 def test_hourly_totals_and_forecast(tmp_path):
     db = tmp_path / "ledger.db"
     ledger = UsageLedger(db_path=str(db))
-    now = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+    now = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
     for i in range(3):
         event = UsageEvent(
             event_id=f"e{i}",

--- a/src/token_tally/usage_ledger.py
+++ b/src/token_tally/usage_ledger.py
@@ -1,7 +1,7 @@
 """Usage event ledger with optional Kafka streaming."""
 
 from dataclasses import dataclass, asdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Optional, Iterable, Any
 import json
 import sqlite3
@@ -94,7 +94,7 @@ class UsageLedger:
 
     def get_hourly_totals(self, hours: int) -> list[float]:
         """Return spend totals for the last ``hours`` hours."""
-        end = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+        end = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
         start = end - timedelta(hours=hours)
         totals = [0.0 for _ in range(hours)]
         with sqlite3.connect(self.db_path) as conn:
@@ -178,7 +178,7 @@ class ClickHouseUsageLedger:
             self.producer.flush()
 
     def get_hourly_totals(self, hours: int) -> list[float]:
-        end = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+        end = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
         start = end - timedelta(hours=hours)
         totals = [0.0 for _ in range(hours)]
         rows = self.client.execute(

--- a/tests/test_clickhouse_ledger.py
+++ b/tests/test_clickhouse_ledger.py
@@ -1,6 +1,6 @@
 import sys
 import pathlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
@@ -30,7 +30,7 @@ def test_clickhouse_ledger_add_and_totals(monkeypatch):
     dummy = DummyClient()
     monkeypatch.setattr(usage_ledger, "Client", lambda *a, **k: dummy)
     ledger = ClickHouseUsageLedger(host="dummy")
-    now = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+    now = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
     event = UsageEvent(
         event_id="e1",
         ts=now - timedelta(hours=1),

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -1,7 +1,8 @@
 import sys
 import pathlib
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
-from datetime import datetime
+from datetime import datetime, UTC
 from token_tally import UsageEvent, UsageLedger
 
 
@@ -10,7 +11,7 @@ def test_add_event(tmp_path):
     ledger = UsageLedger(db_path=str(db_path))
     event = UsageEvent(
         event_id="evt1",
-        ts=datetime.utcnow(),
+        ts=datetime.now(UTC),
         customer_id="cust",
         provider="openai",
         model="gpt-4",


### PR DESCRIPTION
## Summary
- replace deprecated `utcnow()` calls with `datetime.now(datetime.UTC)`
- update tests for timezone-aware datetimes

## Testing
- `pytest -q`
- `npm run build` *(fails: next not found)*