### PR TITLE
Implement AuditLog event deletion

### DIFF
--- a/src/token_tally/audit.py
+++ b/src/token_tally/audit.py
@@ -94,6 +94,15 @@ class AuditLog:
         ]
         return [dict(zip(keys, row)) for row in rows]
 
+    def delete_events(self, customer_id: str) -> None:
+        """Remove all audit events for ``customer_id``."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "DELETE FROM audit_events WHERE customer_id = ?",
+                (customer_id,),
+            )
+            conn.commit()
+
     def verify_chain(self, customer_id: Optional[str] = None) -> bool:
         """Return ``True`` if the hash chain is intact."""
         customers: List[str]

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -36,3 +36,19 @@ def test_hash_chain_verification(tmp_path):
         conn.commit()
 
     assert not log.verify_chain("cust")
+
+
+def test_delete_events_chain_intact(tmp_path):
+    db_path = tmp_path / "audit.db"
+    log = AuditLog(str(db_path))
+    log.add_event("e1", "c1", "foo", 1, datetime(2024, 1, 1))
+    log.add_event("e2", "c2", "bar", 2, datetime(2024, 1, 2))
+    log.add_event("e3", "c1", "baz", 3, datetime(2024, 1, 3))
+    assert log.verify_chain()
+
+    log.delete_events("c1")
+    events = log.list_events()
+    assert len(events) == 1
+    assert events[0]["customer_id"] == "c2"
+    assert log.verify_chain()
+    assert log.verify_chain("c1")


### PR DESCRIPTION
## Summary
- add `delete_events()` to AuditLog to drop all events for a customer
- test event deletion and verifying the chain stays intact

## Testing
- `pytest -q`
- `npm run build` *(fails: `next: not found`)*