### PR TITLE
Add billing CLI module with tests

### DIFF
--- a/src/token_tally/billing_cli.py
+++ b/src/token_tally/billing_cli.py
@@ -1,0 +1,27 @@
+import argparse
+from typing import Iterable
+
+from .billing import BillingService
+from .ledger import Ledger
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Billing utilities")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sync_p = sub.add_parser("sync", help="Sync usage events to Stripe")
+    sync_p.add_argument("db_path", help="Path to ledger.db")
+    sync_p.add_argument("api_key", help="Stripe API key")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.cmd == "sync":
+        service = BillingService(args.api_key, Ledger(args.db_path))
+        count = service.sync_usage_events()
+        print(count)
+
+
+def cli() -> None:
+    main()
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_billing_cli.py
+++ b/tests/test_billing_cli.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import pathlib
+import subprocess
+
+BASE_DIR = pathlib.Path(__file__).resolve().parents[1]
+SRC_DIR = BASE_DIR / "src"
+
+from token_tally.ledger import Ledger  # noqa: E402
+
+
+def test_billing_cli_sync(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    ledger = Ledger(str(db_path))
+    ledger.add_usage_event("e1", "cust", "feat", 5, 0.1, "2024-05")
+
+    # create sitecustomize to stub network call
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(
+        """
+from token_tally.billing import StripeUsageClient
+
+def _fake(self, subscription_item, quantity, timestamp):
+    return {"id": "dummy"}
+
+StripeUsageClient.create_usage_record = _fake
+"""
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), str(SRC_DIR)])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "token_tally.billing_cli",
+            "sync",
+            str(db_path),
+            "sk_test",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+    assert result.stdout.strip() == "1"
+    ledger = Ledger(str(db_path))
+    assert ledger.get_pending_usage_events() == []


### PR DESCRIPTION
## Summary
- add `billing_cli` for syncing usage events
- include CLI test via subprocess

## Testing
- `pytest -q`