### PR TITLE
Add forecast CLI

### DIFF
--- a/src/token_tally/forecast_cli.py
+++ b/src/token_tally/forecast_cli.py
@@ -1,0 +1,22 @@
+import argparse
+from typing import Iterable
+
+from .forecast import forecast_next_hour
+from .usage_ledger import UsageLedger
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Forecast next hour spend")
+    parser.add_argument("db_path", help="Path to ledger.db")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    ledger = UsageLedger(args.db_path)
+    prediction = forecast_next_hour(ledger)
+    print(prediction)
+
+
+def cli() -> None:
+    main()
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_forecast_cli.py
+++ b/tests/test_forecast_cli.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import pathlib
+import subprocess
+from datetime import datetime, timedelta, UTC
+
+BASE_DIR = pathlib.Path(__file__).resolve().parents[1]
+SRC_DIR = BASE_DIR / "src"
+
+sys.path.append(str(SRC_DIR))
+
+from token_tally import UsageEvent, UsageLedger  # noqa: E402
+
+
+def test_forecast_cli(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    ledger = UsageLedger(str(db_path))
+    now = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+    event = UsageEvent(
+        event_id="e1",
+        ts=now - timedelta(hours=1),
+        customer_id="cust",
+        provider="openai",
+        model="gpt",
+        metric_type="tokens",
+        units=10,
+        unit_cost_usd=0.5,
+    )
+    ledger.add_event(event)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC_DIR)
+    result = subprocess.run(
+        [sys.executable, "-m", "token_tally.forecast_cli", str(db_path)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+    assert float(result.stdout.strip()) > 0.0


### PR DESCRIPTION
## Summary
- expose `token_tally.forecast_cli` to forecast hourly spend
- test CLI behaviour via subprocess

## Testing
- `pytest -q`