### PR TITLE
Fix timezone for dead letters

### DIFF
--- a/src/token_tally/usage_ledger.py
+++ b/src/token_tally/usage_ledger.py
@@ -123,7 +123,7 @@ class UsageLedger:
 
     def _write_dead_letter(self, data: dict, error: str) -> None:
         raw = json.dumps(data)
-        ts = datetime.utcnow().isoformat()
+        ts = datetime.now(UTC).isoformat()
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 "INSERT INTO dead_letter_events (raw, error, ts) VALUES (?, ?, ?)",

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -45,3 +45,17 @@ def test_dead_letter_on_malformed(tmp_path):
     raw = json.loads(row[0])
     assert raw["event_id"] == "bad1"
     assert "invalid" in row[1].lower()
+
+
+def test_dead_letter_timestamp_timezone(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    ledger = UsageLedger(db_path=str(db_path))
+    ledger.parse_event({"event_id": "bad2", "ts": "bad"})
+
+    import sqlite3
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute("SELECT ts FROM dead_letter_events")
+        ts = cur.fetchone()[0]
+
+    assert "+00:00" in ts


### PR DESCRIPTION
## Summary
- use `datetime.now(UTC)` when writing dead letter records
- add test verifying timestamps include timezone information

## Testing
- `pytest -q`