### PR TITLE
Add organisation user management

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,3 +10,9 @@ NextAuth is configured in `pages/api/auth/[...nextauth].ts`. The credentials pro
 - `SAML_ENTRYPOINT`, `SAML_ISSUER` and `SAML_CERT` – enable a generic SAML 2.0 provider.
 
 If the variables are not set the corresponding provider is skipped.
+
+## Organisation management
+
+Admins can manage organisation users at `/org-users`. The page lists users and
+allows adding or removing members using tRPC calls backed by a SQLite database
+(`accounts.db`). Only authenticated admins may access the page.

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -19,6 +19,7 @@ export default function Navbar() {
           <Link className="text-blue-600" href="/upload-receipt">{t('navbar.upload')}</Link>
           <Link className="text-blue-600" href="/usage">{t('navbar.usage')}</Link>
           <Link className="text-blue-600" href="/audit">{t('navbar.audit')}</Link>
+          <Link className="text-blue-600" href="/org-users">{t('navbar.users')}</Link>
           <select onChange={changeLocale} value={router.locale} className="border ml-4 p-1">
             <option value="en">EN</option>
             <option value="fr">FR</option>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -28,5 +28,10 @@
   "markup.provider": "Provider",
   "markup.model": "Model",
   "markup.markup": "Markup",
-  "markup.effective": "Effective"
+  "markup.effective": "Effective",
+  "navbar.users": "Users",
+  "users.title": "Organisation Users",
+  "users.add": "Add",
+  "users.remove": "Remove",
+  "users.denied": "Access denied"
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -28,5 +28,10 @@
   "markup.provider": "Fournisseur",
   "markup.model": "Modèle",
   "markup.markup": "Marge",
-  "markup.effective": "Prise d'effet"
+  "markup.effective": "Prise d'effet",
+  "navbar.users": "Utilisateurs",
+  "users.title": "Utilisateurs de l'organisation",
+  "users.add": "Ajouter",
+  "users.remove": "Supprimer",
+  "users.denied": "Accès refusé"
 }

--- a/frontend/pages/org-users.tsx
+++ b/frontend/pages/org-users.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { useSession } from 'next-auth/react'
+import Navbar from '../components/Navbar'
+import { trpc } from '../lib/trpc'
+
+export default function OrgUsers() {
+  const orgId = 'org1'
+  const { data: session, status } = useSession()
+  const utils = trpc.useUtils()
+  const usersQuery = trpc.users.list.useQuery({ orgId }, { enabled: status === 'authenticated' })
+  const add = trpc.users.add.useMutation()
+  const remove = trpc.users.remove.useMutation()
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState('member')
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/login')
+  }, [status, router])
+
+  if (status === 'loading') return <p>Loading...</p>
+
+  const users = usersQuery.data ?? []
+  const isAdmin = users.some(u => u.email === session?.user?.email && u.role === 'admin')
+  if (!isAdmin) return <p>Access denied</p>
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    await add.mutateAsync({ orgId, email, role: role as 'admin' | 'member' })
+    setEmail('')
+    setRole('member')
+    utils.users.list.invalidate({ orgId })
+  }
+
+  async function handleRemove(uEmail: string) {
+    await remove.mutateAsync({ orgId, email: uEmail })
+    utils.users.list.invalidate({ orgId })
+  }
+
+  return (
+    <>
+      <Navbar />
+      <main className="container mx-auto px-4 py-8">
+        <h2 className="text-2xl font-bold mb-4">Organisation Users</h2>
+        <form onSubmit={handleAdd} className="space-x-2 mb-4">
+          <input className="border p-1" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+          <select className="border p-1" value={role} onChange={e => setRole(e.target.value)}>
+            <option value="member">member</option>
+            <option value="admin">admin</option>
+          </select>
+          <button className="bg-blue-600 text-white px-2 py-1 rounded" type="submit">Add</button>
+        </form>
+        <ul className="space-y-2">
+          {users.map(u => (
+            <li key={u.email} className="p-2 bg-white rounded shadow flex justify-between">
+              <span>{u.email} {u.role}</span>
+              <button className="text-red-600" onClick={() => handleRemove(u.email)}>Remove</button>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </>
+  )
+}

--- a/frontend/server/db.ts
+++ b/frontend/server/db.ts
@@ -1,7 +1,30 @@
 import Database from 'better-sqlite3'
+import crypto from 'crypto'
 
 const usageDb = new Database(process.env.USAGE_DB || '../usage_ledger.db')
 const auditDb = new Database(process.env.AUDIT_DB || '../audit_log.db')
+const accountsDb = new Database(process.env.ACCOUNTS_DB || '../accounts.db')
+
+accountsDb
+  .prepare(
+    `CREATE TABLE IF NOT EXISTS organisations (
+       id TEXT PRIMARY KEY,
+       name TEXT NOT NULL
+     )`,
+  )
+  .run()
+
+accountsDb
+  .prepare(
+    `CREATE TABLE IF NOT EXISTS users (
+       id TEXT PRIMARY KEY,
+       org_id TEXT NOT NULL,
+       email TEXT NOT NULL,
+       role TEXT NOT NULL,
+       FOREIGN KEY(org_id) REFERENCES organisations(id)
+     )`,
+  )
+  .run()
 
 export interface UsageQuery {
   start?: string
@@ -31,4 +54,27 @@ export function listUsage(query: UsageQuery = {}) {
 
 export function listAudit() {
   return auditDb.prepare('SELECT * FROM audit_events ORDER BY ts DESC LIMIT 100').all()
+}
+
+export function listUsers(orgId: string) {
+  return accountsDb
+    .prepare('SELECT email, role FROM users WHERE org_id = ? ORDER BY email')
+    .all(orgId)
+}
+
+export function addUser(orgId: string, email: string, role: string) {
+  const id = crypto.randomUUID()
+  accountsDb
+    .prepare('INSERT OR REPLACE INTO users (id, org_id, email, role) VALUES (?, ?, ?, ?)')
+    .run(id, orgId, email, role)
+}
+
+export function removeUser(orgId: string, email: string) {
+  accountsDb.prepare('DELETE FROM users WHERE org_id = ? AND email = ?').run(orgId, email)
+}
+
+export function createOrg(name: string) {
+  const id = crypto.randomUUID()
+  accountsDb.prepare('INSERT INTO organisations (id, name) VALUES (?, ?)').run(id, name)
+  return { id, name }
 }

--- a/frontend/server/router.ts
+++ b/frontend/server/router.ts
@@ -1,6 +1,6 @@
 import { initTRPC } from '@trpc/server'
 import { z } from 'zod'
-import { listUsage, listAudit } from './db'
+import { listUsage, listAudit, listUsers, addUser, removeUser } from './db'
 
 const t = initTRPC.create()
 
@@ -15,6 +15,29 @@ export const appRouter = t.router({
     )
     .query(({ input }) => listUsage(input)),
   audit: t.procedure.query(() => listAudit()),
+  users: t.router({
+    list: t.procedure
+      .input(z.object({ orgId: z.string() }))
+      .query(({ input }) => listUsers(input.orgId)),
+    add: t.procedure
+      .input(
+        z.object({
+          orgId: z.string(),
+          email: z.string().email(),
+          role: z.enum(['admin', 'member']),
+        }),
+      )
+      .mutation(({ input }) => {
+        addUser(input.orgId, input.email, input.role)
+        return true
+      }),
+    remove: t.procedure
+      .input(z.object({ orgId: z.string(), email: z.string() }))
+      .mutation(({ input }) => {
+        removeUser(input.orgId, input.email)
+        return true
+      }),
+  }),
 })
 
 export type AppRouter = typeof appRouter


### PR DESCRIPTION
## Summary
- store organisations and users in new `accounts.db`
- expose `users` router for listing and editing organisation members
- add `/org-users` page with admin-only access
- localise navbar and add new navigation link
- document user management in frontend README

## Testing
- `pytest -q`
