### PR TITLE
Add frontend translations

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -17,7 +17,10 @@
   "register.error": "Registration failed",
   "offers.title": "Available Offers",
   "usage.title": "Usage Explorer",
+  "usage.allCustomers": "All Customers",
+  "usage.apply": "Apply",
   "audit.title": "Audit Trail",
+  "audit.tokens": "{count} tokens",
   "upload.title": "Upload Receipt",
   "upload.button": "Upload",
   "upload.success": "Uploaded!",
@@ -33,5 +36,6 @@
   "users.title": "Organisation Users",
   "users.add": "Add",
   "users.remove": "Remove",
+  "users.loading": "Loading...",
   "users.denied": "Access denied"
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -17,7 +17,10 @@
   "register.error": "Échec de l'inscription",
   "offers.title": "Offres disponibles",
   "usage.title": "Explorateur d'utilisation",
+  "usage.allCustomers": "Tous les clients",
+  "usage.apply": "Appliquer",
   "audit.title": "Historique des audits",
+  "audit.tokens": "{count} jetons",
   "upload.title": "Téléverser un reçu",
   "upload.button": "Téléverser",
   "upload.success": "Téléversé !",
@@ -33,5 +36,6 @@
   "users.title": "Utilisateurs de l'organisation",
   "users.add": "Ajouter",
   "users.remove": "Supprimer",
+  "users.loading": "Chargement...",
   "users.denied": "Accès refusé"
 }

--- a/frontend/pages/audit.tsx
+++ b/frontend/pages/audit.tsx
@@ -14,7 +14,7 @@ export default function Audit() {
         <ul className="space-y-2">
           {logs.map((l: any) => (
             <li key={l.event_id} className="p-2 bg-white rounded shadow">
-              {l.customer_id} {l.token_count} tokens
+              {l.customer_id} {t('audit.tokens', { count: l.token_count })}
             </li>
           ))}
         </ul>

--- a/frontend/pages/org-users.tsx
+++ b/frontend/pages/org-users.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { useSession } from 'next-auth/react'
 import Navbar from '../components/Navbar'
 import { trpc } from '../lib/trpc'
+import { useTranslations } from 'next-intl'
 
 export default function OrgUsers() {
   const orgId = 'org1'
@@ -19,11 +20,13 @@ export default function OrgUsers() {
     if (status === 'unauthenticated') router.push('/login')
   }, [status, router])
 
-  if (status === 'loading') return <p>Loading...</p>
+  const t = useTranslations()
+
+  if (status === 'loading') return <p>{t('users.loading')}</p>
 
   const users = usersQuery.data ?? []
   const isAdmin = users.some(u => u.email === session?.user?.email && u.role === 'admin')
-  if (!isAdmin) return <p>Access denied</p>
+  if (!isAdmin) return <p>{t('users.denied')}</p>
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault()
@@ -42,20 +45,20 @@ export default function OrgUsers() {
     <>
       <Navbar />
       <main className="container mx-auto px-4 py-8">
-        <h2 className="text-2xl font-bold mb-4">Organisation Users</h2>
+        <h2 className="text-2xl font-bold mb-4">{t('users.title')}</h2>
         <form onSubmit={handleAdd} className="space-x-2 mb-4">
-          <input className="border p-1" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+          <input className="border p-1" value={email} onChange={e => setEmail(e.target.value)} placeholder={t('login.email')} />
           <select className="border p-1" value={role} onChange={e => setRole(e.target.value)}>
             <option value="member">member</option>
             <option value="admin">admin</option>
           </select>
-          <button className="bg-blue-600 text-white px-2 py-1 rounded" type="submit">Add</button>
+          <button className="bg-blue-600 text-white px-2 py-1 rounded" type="submit">{t('users.add')}</button>
         </form>
         <ul className="space-y-2">
           {users.map(u => (
             <li key={u.email} className="p-2 bg-white rounded shadow flex justify-between">
               <span>{u.email} {u.role}</span>
-              <button className="text-red-600" onClick={() => handleRemove(u.email)}>Remove</button>
+              <button className="text-red-600" onClick={() => handleRemove(u.email)}>{t('users.remove')}</button>
             </li>
           ))}
         </ul>

--- a/frontend/pages/usage.tsx
+++ b/frontend/pages/usage.tsx
@@ -27,7 +27,7 @@ export default function Usage() {
     <>
       <Navbar />
       <main className="container mx-auto px-4 py-4">
-        <h2 className="text-2xl font-bold mb-4">Usage Explorer</h2>
+        <h2 className="text-2xl font-bold mb-4">{t('usage.title')}</h2>
         <form onSubmit={handleSubmit} className="space-x-2 mb-4">
           <input
             type="date"
@@ -46,7 +46,7 @@ export default function Usage() {
             onChange={e => setCustomer(e.target.value)}
             className="border p-1 rounded"
           >
-            <option value="">All Customers</option>
+            <option value="">{t('usage.allCustomers')}</option>
             {customers.map(c => (
               <option key={c} value={c}>
                 {c}
@@ -54,7 +54,7 @@ export default function Usage() {
             ))}
           </select>
           <button className="bg-blue-600 text-white px-3 py-1 rounded" type="submit">
-            Apply
+            {t('usage.apply')}
           </button>
         </form>
         <ul className="space-y-2">


### PR DESCRIPTION
## Summary
- expand English and French message catalogs
- translate usage explorer, audit, and user admin pages
- wire up translations for user page states

## Testing
- `pytest -q`
- `npm run build` *(fails: `next` not found)*