### PR TITLE
Add multi-region deployment configuration

### DIFF
--- a/gateway-worker/README.md
+++ b/gateway-worker/README.md
@@ -40,3 +40,18 @@ npm run start
 
 The worker expects an `Authorization` header containing the caller's API key.
 Requests exceeding the configured limits receive `HTTP 429` responses.
+
+## Multi-region
+
+Deploy the worker to the default US region with:
+
+```bash
+npm run build
+```
+
+For other regions, specify the environment flag. Example for Europe and APAC:
+
+```bash
+npx wrangler publish --env europe
+npx wrangler publish --env apac
+```

--- a/gateway-worker/wrangler.toml
+++ b/gateway-worker/wrangler.toml
@@ -1,3 +1,15 @@
 name = "token-tally-gateway"
 main = "src/index.ts"
 compatibility_date = "2024-05-01"
+
+[[kv_namespaces]]
+binding = "KEY_LIMITS"
+id = "key_limits_us"
+
+[env.europe]
+data_location = "eu"
+kv_namespaces = [{ binding = "KEY_LIMITS", id = "key_limits_eu" }]
+
+[env.apac]
+data_location = "apac"
+kv_namespaces = [{ binding = "KEY_LIMITS", id = "key_limits_apac" }]


### PR DESCRIPTION
## Summary
- configure EU and APAC environments in the worker
- document how to publish to each region

## Testing
- `pytest -q`
- `npm run build` *(fails: `next` not found)*