### PR TITLE
Load provider data from config file

### DIFF
--- a/gateway-worker/README.md
+++ b/gateway-worker/README.md
@@ -16,6 +16,19 @@ key using a KV namespace or an environment variable containing JSON.
 | `KEY_LIMITS_JSON` | Optional JSON object mapping API keys to `{ "concurrency": n, "rate": m }` |
 | `KEY_LIMITS` | Optional KV namespace for per-key limit objects |
 
+Provider base URLs are defined in `providers.json` at the project root. Each key
+maps the provider name used in the `X-LLM-Provider` header to the base URL that
+should receive the request.
+
+Example `providers.json`:
+
+```json
+{
+  "openai": "https://api.openai.com",
+  "anthropic": "https://api.anthropic.com"
+}
+```
+
 Values found in `KEY_LIMITS_JSON` or `KEY_LIMITS` override the defaults for the
 matching API key. A limit value of `0` means no limit for that field.
 

--- a/gateway-worker/providers.json
+++ b/gateway-worker/providers.json
@@ -1,0 +1,4 @@
+{
+  "openai": "https://api.openai.com",
+  "anthropic": "https://api.anthropic.com"
+}

--- a/gateway-worker/src/index.ts
+++ b/gateway-worker/src/index.ts
@@ -7,10 +7,8 @@ export interface Env {
   KEY_LIMITS_JSON?: string;
 }
 
-const PROVIDER_BASE: Record<string, string> = {
-  openai: 'https://api.openai.com',
-  anthropic: 'https://api.anthropic.com',
-};
+import providerConfig from '../providers.json';
+const PROVIDER_BASE: Record<string, string> = providerConfig;
 
 const DEFAULT_CONCURRENCY_LIMIT = 5;
 const DEFAULT_RATE_LIMIT = 60; // requests per minute

--- a/gateway-worker/tsconfig.json
+++ b/gateway-worker/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Node",
     "strict": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist"


### PR DESCRIPTION
## Summary
- pull provider base URLs from `providers.json`
- reference `providers.json` in gateway worker docs
- enable JSON imports for the worker

## Testing
- `pytest -q`
- `npm run build` *(fails: wrangler not found)*