### PR TITLE
Add ClickHouse EU region option

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Stripe Invoice → Customer
 ### Data residency options
 
 TokenTally runs in US-East by default. Enterprise customers may pin all data processing to the EU region or deploy the gateway inside their own Kubernetes clusters using the Helm chart under `helm/token-tally`.
+Set the environment variable `EU_CLICKHOUSE_HOST` to the hostname of the EU ClickHouse cluster when using the `region="eu"` option in the backend.
 
 ## Frontend
 A Next.js + tRPC admin portal lives in `frontend/`. Run `npm install` in that

--- a/src/token_tally/usage_ledger.py
+++ b/src/token_tally/usage_ledger.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, UTC
 from typing import Optional, Iterable, Any
+import os
 import json
 import sqlite3
 
@@ -197,12 +198,15 @@ class ClickHouseUsageLedger:
         self,
         host: str = "localhost",
         *,
+        region: Optional[str] = None,
         kafka_servers: Optional[Iterable[str]] = None,
         kafka_topic: str = "usage_events",
         **client_kwargs: Any,
     ) -> None:
         if Client is None:
             raise ImportError("clickhouse-driver not installed")
+        if region == "eu":
+            host = os.getenv("EU_CLICKHOUSE_HOST", host)
         self.client = Client(host=host, **client_kwargs)
         self.kafka_topic = kafka_topic
         self.producer = None

--- a/tests/test_clickhouse_ledger.py
+++ b/tests/test_clickhouse_ledger.py
@@ -47,3 +47,20 @@ def test_clickhouse_ledger_add_and_totals(monkeypatch):
 
     totals = ledger.get_hourly_totals(2)
     assert totals[1] == 1.0
+
+
+def test_region_selects_eu_host(monkeypatch):
+    class DummyClientHost(DummyClient):
+        def __init__(self, host):
+            super().__init__()
+            self.host = host
+
+    monkeypatch.setenv("EU_CLICKHOUSE_HOST", "eu.example.com")
+    monkeypatch.setattr(
+        usage_ledger,
+        "Client",
+        lambda *, host="localhost", **k: DummyClientHost(host),
+    )
+    ledger = ClickHouseUsageLedger(region="eu")
+    assert isinstance(ledger.client, DummyClientHost)
+    assert ledger.client.host == "eu.example.com"


### PR DESCRIPTION
## Summary
- add `region` param to `ClickHouseUsageLedger`
- document `EU_CLICKHOUSE_HOST` env var
- test EU region selection logic

## Testing
- `black src/token_tally/usage_ledger.py tests/test_clickhouse_ledger.py --quiet`
- `pytest -q`