### PR TITLE
Add Ollama token count support

### DIFF
--- a/gateway-worker/src/index.ts
+++ b/gateway-worker/src/index.ts
@@ -3,6 +3,7 @@ export interface Env {
   WEBHOOK_URL?: string;
   CONCURRENCY_LIMIT?: string;
   RATE_LIMIT?: string;
+  OLLAMA_BASE?: string;
   KEY_LIMITS?: KVNamespace;
   KEY_LIMITS_JSON?: string;
 }
@@ -10,6 +11,7 @@ export interface Env {
 const PROVIDER_BASE: Record<string, string> = {
   openai: 'https://api.openai.com',
   anthropic: 'https://api.anthropic.com',
+  ollama: 'http://127.0.0.1:11434',
 };
 
 const DEFAULT_CONCURRENCY_LIMIT = 5;
@@ -152,7 +154,11 @@ export default {
       }
 
       const provider = request.headers.get('X-LLM-Provider') || 'openai';
-      const base = PROVIDER_BASE[provider.toLowerCase()];
+      const providerKey = provider.toLowerCase();
+      let base = PROVIDER_BASE[providerKey];
+      if (providerKey === 'ollama' && env.OLLAMA_BASE) {
+        base = env.OLLAMA_BASE;
+      }
       if (!base) {
         exitConcurrency(apiKey);
         return new Response('Unknown provider', { status: 400 });

--- a/src/token_tally/__init__.py
+++ b/src/token_tally/__init__.py
@@ -3,6 +3,7 @@ from .audit import AuditLog
 from .token_counter import (
     count_openai_tokens,
     count_anthropic_tokens,
+    count_ollama_tokens,
     count_local_tokens,
     count_tokens,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "AuditLog",
     "count_openai_tokens",
     "count_anthropic_tokens",
+    "count_ollama_tokens",
     "count_local_tokens",
     "count_tokens",
     "parse_dcgm_gpu_minutes",

--- a/tests/test_token_counter.py
+++ b/tests/test_token_counter.py
@@ -23,14 +23,29 @@ def _expected_anthropic(text: str) -> int:
     return len(tc._regex_split(text))
 
 
+def _expected_ollama(text: str) -> int:
+    if importlib.util.find_spec("ollama"):
+        import ollama  # type: ignore
+
+        tokenize = getattr(ollama, "tokenize", None)
+        if callable(tokenize):
+            try:
+                return len(tokenize(text))
+            except Exception:
+                pass
+    return len(tc._regex_split(text))
+
+
 def test_count_tokens():
     assert tt.count_openai_tokens("hello world!") == _expected_openai("hello world!")
     assert tt.count_anthropic_tokens("chatGPT") == _expected_anthropic("chatGPT")
+    assert tt.count_ollama_tokens("hi there") == _expected_ollama("hi there")
     assert tt.count_local_tokens("one two three") == 3
     assert tt.count_tokens("openai", "foo bar") == _expected_openai("foo bar")
     assert tt.count_tokens("anthropic", "foo bar baz") == _expected_anthropic(
         "foo bar baz"
     )
+    assert tt.count_tokens("ollama", "zap zap") == _expected_ollama("zap zap")
     assert tt.count_tokens("local", "a b c d") == 4
 
 


### PR DESCRIPTION
## Summary
- allow Ollama provider in the gateway with configurable base URL
- implement `count_ollama_tokens` and map provider name
- export new function from package
- test Ollama token counting

## Testing
- `black .`
- `pytest -q`