### PR TITLE
Add discovery call script documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,13 @@ Stripe Invoice → Customer
 
 | Action                                             | Owner    | Due         |
 | -------------------------------------------------- | -------- | ----------- |
-| Conduct 20 customer discovery calls (script ready) | Product  | 14 Jun 2025 |
+| Conduct 20 customer discovery calls ([script](docs/customer_discovery_calls.md)) | Product  | 14 Jun 2025 |
 | Fork Portkey, bolt ClickHouse & Stripe hook (PoC)  | Eng Lead | 05 Jun 2025 |
 | Draft security architecture doc for SOC readiness  | CISO     | 28 Jun 2025 |
 | Prepare one-pager + deck for \$1.5 M pre-seed      | GM       | 21 Jun 2025 |
 | Line up design-partner LOIs (3 SaaS, 2 Enterprise) | Sales    | 30 Jun 2025 |
+
+See [docs/customer_discovery_calls.md](docs/customer_discovery_calls.md) for the full discovery call script.
 
 ---
 **Bottom line:** This gateway solves a *real*, boring accounting problem nobody wants to touch. Nail deterministic metering, stay invisible in the hot path, and invoice cleanly—everything else is a feature-creep distraction.

--- a/docs/customer_discovery_calls.md
+++ b/docs/customer_discovery_calls.md
@@ -1,0 +1,26 @@
+# Customer Discovery Call Script
+
+This script guides each of the twenty planned discovery calls. Keep the conversation informal but hit each question to uncover the prospect's current pain around LLM cost tracking and billing.
+
+1. Thank them for taking the time and confirm how much time they have.
+2. Ask for a quick overview of their product or service.
+3. How are they using large language models today?
+4. Which providers or models are in their stack?
+5. Who is responsible for monitoring usage and spend?
+6. What tools do they rely on today for usage tracking?
+7. How accurate do they feel their current usage numbers are?
+8. Do they allocate model costs back to features or customers?
+9. What is the biggest frustration with existing billing data?
+10. Have they ever been surprised by a large model invoice?
+11. How do finance and engineering collaborate on cost issues?
+12. Are there any home-grown scripts or spreadsheets in place?
+13. What metrics or dashboards do leadership ask for?
+14. Do they need real-time budget alerts or just monthly reports?
+15. How are customers currently invoiced for model usage?
+16. What would an ideal invoicing workflow look like for them?
+17. How important is SOC 2 or data residency for adoption?
+18. Would they prefer a cloud service or self-hosted option?
+19. If we solved this problem well, what would success look like?
+20. May we follow up once we have a beta available?
+
+Capture notable quotes after each call and aggregate common themes to refine the product roadmap.

--- a/receipt_processor/ocr.py
+++ b/receipt_processor/ocr.py
@@ -1,6 +1,7 @@
 import subprocess
 from pathlib import Path
 
+
 class OCREngine:
     """Simple wrapper around the `tesseract` CLI."""
 

--- a/receipt_processor/offer_matching.py
+++ b/receipt_processor/offer_matching.py
@@ -14,7 +14,7 @@ class OfferMatcher:
         if not line:
             return None
         # Match by UPC first
-        digits = ''.join(ch for ch in line if ch.isdigit())
+        digits = "".join(ch for ch in line if ch.isdigit())
         if digits:
             for offer in self.offers:
                 if offer.get("upc") and offer["upc"] in digits:
@@ -23,7 +23,9 @@ class OfferMatcher:
         best_offer = None
         best_ratio = 0.0
         for offer in self.offers:
-            ratio = SequenceMatcher(None, offer.get("name", "").lower(), line.lower()).ratio()
+            ratio = SequenceMatcher(
+                None, offer.get("name", "").lower(), line.lower()
+            ).ratio()
             if ratio > best_ratio:
                 best_ratio = ratio
                 best_offer = offer

--- a/receipt_processor/service.py
+++ b/receipt_processor/service.py
@@ -18,23 +18,28 @@ class ReceiptHandler(BaseHTTPRequestHandler):
         if self.path != "/upload":
             self.send_error(404)
             return
-        content_type = self.headers.get('Content-Type')
+        content_type = self.headers.get("Content-Type")
         if not content_type:
             self.send_error(400, "Missing Content-Type")
             return
         ctype, pdict = cgi.parse_header(content_type)
-        if ctype != 'multipart/form-data':
+        if ctype != "multipart/form-data":
             self.send_error(400, "Expected multipart form data")
             return
-        pdict['boundary'] = bytes(pdict['boundary'], "utf-8")
-        pdict['CONTENT-LENGTH'] = int(self.headers.get('Content-Length'))
-        form = cgi.FieldStorage(fp=self.rfile, headers=self.headers, environ={'REQUEST_METHOD':'POST'}, keep_blank_values=True)
-        file_item = form['file'] if 'file' in form else None
+        pdict["boundary"] = bytes(pdict["boundary"], "utf-8")
+        pdict["CONTENT-LENGTH"] = int(self.headers.get("Content-Length"))
+        form = cgi.FieldStorage(
+            fp=self.rfile,
+            headers=self.headers,
+            environ={"REQUEST_METHOD": "POST"},
+            keep_blank_values=True,
+        )
+        file_item = form["file"] if "file" in form else None
         if file_item is None or not file_item.file:
             self.send_error(400, "No file uploaded")
             return
         tmp_path = DATA_DIR / file_item.filename
-        with open(tmp_path, 'wb') as f:
+        with open(tmp_path, "wb") as f:
             f.write(file_item.file.read())
         results = processor.process_receipt(tmp_path)
         response = json.dumps(results).encode()

--- a/receipt_processor/tests/test_matcher.py
+++ b/receipt_processor/tests/test_matcher.py
@@ -1,4 +1,5 @@
 import sys, pathlib
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 from pathlib import Path
 from receipt_processor.offer_matching import OfferMatcher
@@ -8,11 +9,17 @@ def test_match_line_by_upc(tmp_path):
     offers_path = tmp_path / "offers.json"
     offers_path.write_text('[{"upc": "111222333444", "name": "Test Prod"}]')
     matcher = OfferMatcher(offers_path)
-    assert matcher.match_line("111222333444 SOME ITEM") == {"upc": "111222333444", "name": "Test Prod"}
+    assert matcher.match_line("111222333444 SOME ITEM") == {
+        "upc": "111222333444",
+        "name": "Test Prod",
+    }
 
 
 def test_match_line_by_name(tmp_path):
     offers_path = tmp_path / "offers.json"
     offers_path.write_text('[{"upc": "555", "name": "Special Snack"}]')
     matcher = OfferMatcher(offers_path)
-    assert matcher.match_line("special snack large") == {"upc": "555", "name": "Special Snack"}
+    assert matcher.match_line("special snack large") == {
+        "upc": "555",
+        "name": "Special Snack",
+    }

--- a/src/token_tally/gpu_metrics.py
+++ b/src/token_tally/gpu_metrics.py
@@ -33,4 +33,5 @@ def parse_dcgm_gpu_minutes(lines: Iterable[str]) -> float:
 
     return total_util_seconds / 60.0
 
+
 __all__ = ["parse_dcgm_gpu_minutes"]


### PR DESCRIPTION
## Summary
- black-format Python files
- add a customer discovery call script under `docs/`
- link to the script in the `Next-step action items` section of the README

## Testing
- `pytest -q`
