### PR TITLE
Add pre-seed pitch deck outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,6 @@ python -m token_tally.stripe_webhook whsec_test --db-path ledger.db --port 9000
 ```
 
 Configure Stripe to send webhooks to `http://localhost:9000/webhook`.
+
+## Pre-seed pitch deck
+The slide outline for our $1.5 M raise lives in [`docs/preseed_pitch_deck/outline.md`](docs/preseed_pitch_deck/outline.md).

--- a/docs/preseed_pitch_deck/outline.md
+++ b/docs/preseed_pitch_deck/outline.md
@@ -1,0 +1,10 @@
+# TokenTally Pre-Seed Deck Outline
+
+1. **Problem** – opaque AI usage bills and manual reconciliation
+2. **Solution** – drop-in gateway that meters tokens and sends clean invoices
+3. **Market** – exploding spend on generative AI services; FinOps teams starved for usage data
+4. **Product** – demo of gateway passthrough, Stripe integration and dashboards
+5. **Traction** – design partners committed, prototype metering accuracy at ±0.1 %
+6. **Business Model** – usage-based pricing with enterprise upsell for on-prem
+7. **Roadmap** – MVP beta to GA cloud, followed by enterprise features
+8. **Team & Ask** – founding crew background and request for $1.5 M to reach GA


### PR DESCRIPTION
## Summary
- document the pre-seed deck outline under `docs/`
- link to the outline in the README

## Testing
- `pytest -q`
- `npm run build` *(fails: `next` not found)*