### PR TITLE
Add GPU arbitrage helper with routing and tests

### DIFF
--- a/src/token_tally/__init__.py
+++ b/src/token_tally/__init__.py
@@ -9,11 +9,13 @@ from .token_counter import (
     count_tokens,
 )
 from .gpu_metrics import parse_dcgm_gpu_minutes
+from .gpu_arbitrage import choose_best_gpu_host
 from .ledger import Ledger
 from .payout import StripePayoutClient, PayoutService
 from .forecast import arima_forecast, forecast_next_hour
 from .metrics import REQUEST_COUNTER, TOKEN_COUNTER, start_metrics_server
 from .alerts import send_webhook_message
+from .cost_router import route_provider
 
 __all__ = [
     "UsageEvent",
@@ -27,6 +29,7 @@ __all__ = [
     "count_local_tokens",
     "count_tokens",
     "parse_dcgm_gpu_minutes",
+    "choose_best_gpu_host",
     "Ledger",
     "StripePayoutClient",
     "REQUEST_COUNTER",
@@ -36,4 +39,5 @@ __all__ = [
     "arima_forecast",
     "forecast_next_hour",
     "send_webhook_message",
+    "route_provider",
 ]

--- a/src/token_tally/cost_router.py
+++ b/src/token_tally/cost_router.py
@@ -1,0 +1,30 @@
+"""Provider base URL routing with GPU spot-price support."""
+
+from __future__ import annotations
+
+import os
+
+from .gpu_arbitrage import choose_best_gpu_host
+
+PROVIDER_BASE = {
+    "openai": os.environ.get("OPENAI_BASE", "https://api.openai.com/v1"),
+    "anthropic": os.environ.get("ANTHROPIC_BASE", "https://api.anthropic.com"),
+    "cohere": os.environ.get("COHERE_BASE", "https://api.cohere.ai"),
+}
+
+
+def route_provider(provider: str, model: str | None = None) -> str:
+    """Return the base URL for ``provider``.
+
+    ``local``/``ollama`` providers route to the cheapest GPU host.
+    """
+    key = provider.lower()
+    if key in {"local", "ollama"}:
+        return choose_best_gpu_host()
+    base = PROVIDER_BASE.get(key)
+    if base is None:
+        raise ValueError(f"unknown provider: {provider}")
+    return base
+
+
+__all__ = ["route_provider"]

--- a/src/token_tally/gpu_arbitrage.py
+++ b/src/token_tally/gpu_arbitrage.py
@@ -1,0 +1,23 @@
+"""Helpers for selecting the cheapest GPU host."""
+
+from __future__ import annotations
+
+import json
+import os
+from urllib.request import urlopen
+
+
+def choose_best_gpu_host(feed_url: str | None = None) -> str:
+    """Return the host with the lowest spot price."""
+    feed_url = feed_url or os.getenv("GPU_SPOT_FEED")
+    if not feed_url:
+        raise ValueError("feed_url must be provided")
+    with urlopen(feed_url) as resp:
+        data = json.loads(resp.read().decode())
+    if not isinstance(data, dict) or not data:
+        raise ValueError("invalid price feed")
+    host = min(data.items(), key=lambda item: item[1])[0]
+    return host
+
+
+__all__ = ["choose_best_gpu_host"]

--- a/tests/test_gpu_arbitrage.py
+++ b/tests/test_gpu_arbitrage.py
@@ -1,0 +1,33 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from token_tally import gpu_arbitrage, cost_router
+
+
+class DummyResp:
+    def __init__(self, data: bytes):
+        self.data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def read(self) -> bytes:
+        return self.data
+
+
+def test_choose_best_gpu_host(monkeypatch):
+    data = b'{"h1": 0.5, "h2": 0.3}'
+    monkeypatch.setattr(gpu_arbitrage, "urlopen", lambda url: DummyResp(data))
+    host = gpu_arbitrage.choose_best_gpu_host("http://feed")
+    assert host == "h2"
+
+
+def test_cost_router_local(monkeypatch):
+    monkeypatch.setattr(cost_router, "choose_best_gpu_host", lambda: "best")
+    base = cost_router.route_provider("local")
+    assert base == "best"

--- a/tests/test_token_counter.py
+++ b/tests/test_token_counter.py
@@ -24,6 +24,9 @@ def _expected_anthropic(text: str) -> int:
 
 
 def _expected_cohere(text: str) -> int:
+    return len(tc._regex_split(text))
+
+
 def _expected_ollama(text: str) -> int:
     if importlib.util.find_spec("ollama"):
         import ollama  # type: ignore


### PR DESCRIPTION
## Summary
- implement `choose_best_gpu_host` in new `gpu_arbitrage` module
- add `cost_router.route_provider` using GPU arbitrage for local models
- expose new helpers from `token_tally` package
- fix missing body in `tests/test_token_counter.py`
- add unit tests for GPU arbitrage

## Testing
- `pytest -q`