### PR TITLE
Add commitment manager CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Finance leaders are sick of reconciling five-and-six-figure “mystery bills” 
    * `python -m token_tally.budget_alert ledger.db https://hook` can be run
      hourly via cron to notify when a customer exceeds their monthly budget.
    * Hard-stop capability (`HTTP 429`) if customer hits credit limit.
+   * `python -m token_tally.commitment_manager analyze ledger.db` suggests
+     reserved-capacity commitments from historical usage.
 
 7. **Admin Portal** (Next.js + tRPC)
 

--- a/src/token_tally/__init__.py
+++ b/src/token_tally/__init__.py
@@ -12,6 +12,7 @@ from .payout import StripePayoutClient, PayoutService
 from .forecast import arima_forecast, forecast_next_hour
 from .metrics import REQUEST_COUNTER, TOKEN_COUNTER, start_metrics_server
 from .alerts import send_webhook_message
+from .commitment_manager import suggest_commitments
 
 __all__ = [
     "UsageEvent",
@@ -32,4 +33,5 @@ __all__ = [
     "arima_forecast",
     "forecast_next_hour",
     "send_webhook_message",
+    "suggest_commitments",
 ]

--- a/src/token_tally/commitment_manager.py
+++ b/src/token_tally/commitment_manager.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, UTC
+from typing import Dict, Iterable
+
+from .ledger import Ledger
+
+
+def suggest_commitments(
+    ledger: Ledger,
+    months: int = 3,
+    reserve_ratio: float = 0.8,
+) -> Dict[str, float]:
+    """Return commitment suggestions keyed by customer_id."""
+    start_dt = datetime.now(UTC) - timedelta(days=30 * months)
+    start = start_dt.strftime("%Y-%m-%d")
+    end = datetime.now(UTC).strftime("%Y-%m-%d")
+    events = ledger.get_usage_events_by_range(start, end)
+    totals: Dict[str, float] = {}
+    for ev in events:
+        cost = ev.get("units", 0) * ev.get("unit_cost", 0.0)
+        cust = ev.get("customer_id", "")
+        totals[cust] = totals.get(cust, 0.0) + cost
+    avg_per_month = {cid: total / months for cid, total in totals.items()}
+    return {cid: round(avg * reserve_ratio, 2) for cid, avg in avg_per_month.items()}
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Reserved capacity commitment manager")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    analyze_p = sub.add_parser("analyze", help="Analyze historical usage")
+    analyze_p.add_argument("db_path", help="Path to ledger.db")
+    analyze_p.add_argument(
+        "--months",
+        type=int,
+        default=3,
+        help="Number of months to analyze",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.cmd == "analyze":
+        ledger = Ledger(args.db_path)
+        suggestions = suggest_commitments(ledger, months=args.months)
+        for cust_id in sorted(suggestions):
+            print(f"{cust_id},{suggestions[cust_id]:.2f}")
+
+
+def cli() -> None:
+    main()
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_commitment_manager.py
+++ b/tests/test_commitment_manager.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import pathlib
+import subprocess
+from datetime import datetime, timedelta, UTC
+
+BASE_DIR = pathlib.Path(__file__).resolve().parents[1]
+SRC_DIR = BASE_DIR / "src"
+
+sys.path.append(str(SRC_DIR))
+
+from token_tally.ledger import Ledger  # noqa: E402
+
+
+def test_commitment_analyze_cli(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    ledger = Ledger(str(db_path))
+    now = datetime.now(UTC)
+    ledger.add_usage_event(
+        "e1",
+        "cust1",
+        "feat",
+        10,
+        1.0,
+        "2024-05",
+        ts=now - timedelta(days=10),
+    )
+    ledger.add_usage_event(
+        "e2",
+        "cust1",
+        "feat",
+        10,
+        1.0,
+        "2024-04",
+        ts=now - timedelta(days=40),
+    )
+    ledger.add_usage_event(
+        "e3",
+        "cust2",
+        "feat",
+        20,
+        2.0,
+        "2024-05",
+        ts=now - timedelta(days=5),
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC_DIR)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "token_tally.commitment_manager",
+            "analyze",
+            str(db_path),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+    lines = result.stdout.strip().splitlines()
+    data = dict(line.split(",") for line in lines if line)
+    assert abs(float(data["cust1"]) - 5.33) < 0.01
+    assert abs(float(data["cust2"]) - 10.67) < 0.01


### PR DESCRIPTION
## Summary
- implement `commitment_manager` module for analyzing historical usage
- expose `python -m token_tally.commitment_manager analyze ledger.db`
- document CLI usage in README
- export `suggest_commitments` in package
- add tests for the new CLI

## Testing
- `pytest -q`