### PR TITLE
Add Okta auth provider

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,6 +7,7 @@ This folder contains the Next.js admin portal. Install dependencies with `npm in
 NextAuth is configured in `pages/api/auth/[...nextauth].ts`. The credentials provider is always enabled. Google and SAML providers are added if the following environment variables are present:
 
 - `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` – enable Google sign-in.
+- `OKTA_CLIENT_ID` and `OKTA_CLIENT_SECRET` – enable Okta sign-in. `OKTA_ISSUER` can also be provided for multi-tenant setups.
 - `SAML_ENTRYPOINT`, `SAML_ISSUER` and `SAML_CERT` – enable a generic SAML 2.0 provider.
 
 If the variables are not set the corresponding provider is skipped.

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,7 @@
 import NextAuth from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import GoogleProvider from 'next-auth/providers/google'
+import OktaProvider from 'next-auth/providers/okta'
 import SAMLProvider from 'next-auth/providers/saml'
 
 const providers = [
@@ -24,6 +25,16 @@ if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    })
+  )
+}
+
+if (process.env.OKTA_CLIENT_ID && process.env.OKTA_CLIENT_SECRET) {
+  providers.push(
+    OktaProvider({
+      clientId: process.env.OKTA_CLIENT_ID,
+      clientSecret: process.env.OKTA_CLIENT_SECRET,
+      issuer: process.env.OKTA_ISSUER,
     })
   )
 }

--- a/tests/load_nextauth.mjs
+++ b/tests/load_nextauth.mjs
@@ -17,6 +17,9 @@ const linker = async (specifier) => {
   if (specifier === 'next-auth/providers/google') {
     return new vm.SourceTextModule('export default (o) => ({ id: "google", opts: o });', { context });
   }
+  if (specifier === 'next-auth/providers/okta') {
+    return new vm.SourceTextModule('export default (o) => ({ id: "okta", opts: o });', { context });
+  }
   if (specifier === 'next-auth/providers/saml') {
     return new vm.SourceTextModule('export default (o) => ({ id: "saml", opts: o });', { context });
   }

--- a/tests/test_nextauth_config.py
+++ b/tests/test_nextauth_config.py
@@ -33,6 +33,12 @@ def test_load_google():
     assert "google" in ids
 
 
+def test_load_okta():
+    cfg = load_config({"OKTA_CLIENT_ID": "id", "OKTA_CLIENT_SECRET": "sec"})
+    ids = [p["id"] for p in cfg["providers"]]
+    assert "okta" in ids
+
+
 def test_load_saml():
     cfg = load_config(
         {"SAML_ENTRYPOINT": "url", "SAML_ISSUER": "iss", "SAML_CERT": "cert"}


### PR DESCRIPTION
## Summary
- enable Okta auth provider in NextAuth when OKTA env vars are present
- document Okta environment variables
- add tests and loader support for the Okta provider

## Testing
- `pytest -q`
- `npm run build` *(fails: next not found)*