### PR TITLE
Add privateLink option to Helm chart

### DIFF
--- a/helm/token-tally/README.md
+++ b/helm/token-tally/README.md
@@ -15,4 +15,8 @@ image:
   tag: latest
 service:
   type: LoadBalancer
+privateLink:
+  enabled: true
 ```
+
+Set `privateLink.enabled` to `true` when you need the service exposed via an internal load balancer for PrivateLink deployments.

--- a/helm/token-tally/templates/service.yaml
+++ b/helm/token-tally/templates/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "token-tally.fullname" . }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.privateLink.enabled }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/helm/token-tally/values.yaml
+++ b/helm/token-tally/values.yaml
@@ -8,3 +8,6 @@ image:
 service:
   type: ClusterIP
   port: 8000
+
+privateLink:
+  enabled: false


### PR DESCRIPTION
## Summary
- allow internal load balancer toggle via `privateLink.enabled`
- document the option in Helm README
- provide default value in chart

## Testing
- `pytest -q`
