### PR TITLE
Implement cost routing for provider selection

### DIFF
--- a/src/token_tally/__init__.py
+++ b/src/token_tally/__init__.py
@@ -12,6 +12,7 @@ from .payout import StripePayoutClient, PayoutService
 from .forecast import arima_forecast, forecast_next_hour
 from .metrics import REQUEST_COUNTER, TOKEN_COUNTER, start_metrics_server
 from .alerts import send_webhook_message
+from .cost_router import route_request
 
 __all__ = [
     "UsageEvent",
@@ -32,4 +33,5 @@ __all__ = [
     "arima_forecast",
     "forecast_next_hour",
     "send_webhook_message",
+    "route_request",
 ]

--- a/src/token_tally/cost_router.py
+++ b/src/token_tally/cost_router.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, UTC
+from typing import Iterable, Optional, Dict, Any
+
+from .markup import get_effective_markup
+from .fx_rates import get_rates
+from .fx import convert
+
+
+@dataclass
+class ProviderOption:
+    provider: str
+    model: str
+    unit_cost: float
+    currency: str = "USD"
+    extra: Dict[str, Any] | None = None
+
+
+def _final_cost(
+    option: ProviderOption,
+    ts: datetime,
+    rates: Dict[str, float],
+    markup_db_path: str,
+    target_currency: str,
+) -> float:
+    rule = get_effective_markup(
+        option.provider, option.model, ts.isoformat(), db_path=markup_db_path
+    )
+    markup = rule["markup"] if rule else 0.0
+    cost = option.unit_cost * (1 + markup)
+    if option.currency != target_currency and rates:
+        cost = convert(cost, option.currency, target_currency, rates)
+    return cost
+
+
+def route_request(
+    options: Iterable[Dict[str, Any]] | Iterable[ProviderOption],
+    model: str,
+    *,
+    ts: Optional[datetime] = None,
+    markup_db_path: str = "markup_rules.db",
+    fx_db_path: str = "fx_rates.db",
+    target_currency: str = "USD",
+) -> Dict[str, Any]:
+    """Return provider option with the lowest cost.
+
+    ``options`` is an iterable of provider descriptions. Each must include
+    ``provider``, ``model`` and ``unit_cost`` fields and may include a
+    ``currency`` field (default ``USD``). The returned dict includes a
+    ``final_cost`` key with the computed price in ``target_currency``.
+    """
+
+    opts: list[ProviderOption] = []
+    for o in options:
+        if isinstance(o, ProviderOption):
+            opts.append(o)
+        else:
+            opts.append(
+                ProviderOption(
+                    provider=o["provider"],
+                    model=o.get("model", model),
+                    unit_cost=o["unit_cost"],
+                    currency=o.get("currency", "USD"),
+                    extra={
+                        k: v
+                        for k, v in o.items()
+                        if k not in {"provider", "model", "unit_cost", "currency"}
+                    },
+                )
+            )
+
+    if not opts:
+        raise ValueError("no provider options")
+
+    ts = ts or datetime.now(UTC)
+    rates = get_rates(db_path=fx_db_path)
+
+    best: Optional[ProviderOption] = None
+    best_cost = float("inf")
+    for opt in opts:
+        cost = _final_cost(opt, ts, rates, markup_db_path, target_currency)
+        if cost < best_cost:
+            best = opt
+            best_cost = cost
+    if best is None:
+        raise ValueError("no provider options")
+    result = {
+        "provider": best.provider,
+        "model": best.model,
+        "unit_cost": best.unit_cost,
+        "currency": best.currency,
+        "final_cost": best_cost,
+    }
+    if best.extra:
+        result.update(best.extra)
+    return result

--- a/tests/test_cost_router.py
+++ b/tests/test_cost_router.py
@@ -1,0 +1,41 @@
+import sys
+import pathlib
+from datetime import datetime
+
+BASE_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(BASE_DIR / "src"))
+
+import pytest
+
+from token_tally.markup import MarkupRuleStore
+from token_tally.fx_rates import store_rates
+from token_tally.cost_router import route_request
+
+
+def test_route_request_cheapest(tmp_path):
+    markup_db = tmp_path / "rules.db"
+    store = MarkupRuleStore(str(markup_db))
+    store.create_rule("r1", "openai", "gpt-4", 0.2, "2024-01-01")
+    store.create_rule("r2", "cohere", "gpt-4", 0.0, "2024-01-01")
+
+    fx_db = tmp_path / "fx.db"
+    store_rates({"EUR": 1.0, "USD": 1.2}, fetch_date="2024-06-01", db_path=str(fx_db))
+
+    options = [
+        {"provider": "openai", "model": "gpt-4", "unit_cost": 0.02, "currency": "USD"},
+        {"provider": "cohere", "model": "gpt-4", "unit_cost": 0.018, "currency": "EUR"},
+    ]
+    result = route_request(
+        options,
+        "gpt-4",
+        ts=datetime(2024, 6, 1),
+        markup_db_path=str(markup_db),
+        fx_db_path=str(fx_db),
+    )
+    assert result["provider"] == "cohere"
+    assert round(result["final_cost"], 6) == round(0.018 * 1.2, 6)
+
+
+def test_route_request_no_options():
+    with pytest.raises(ValueError):
+        route_request([], "gpt")


### PR DESCRIPTION
## Summary
- add `cost_router.py` to choose cheapest provider based on markup rules and FX rates
- expose `route_request` via `token_tally` package
- test cost router logic

## Testing
- `black -q src tests`
- `pytest -q`