### PR TITLE
Add SOC2 monitoring script

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Finance leaders are sick of reconciling five-and-six-figure “mystery bills” 
    * SOC 2 roadmap published; see "SOC 2 & Data Residency" below.
    * Data residency: US or EU-managed clusters, or self-host via Helm.
    * Private-cloud (Helm chart) for Enterprise tier (see `helm/token-tally`).
+   * `python -m token_tally.soc2_monitor audit.db http://localhost:8000/health`
+     can be run every 5 minutes via cron to verify audit-log integrity and
+     service health.
 
 ---
 

--- a/src/token_tally/soc2_monitor.py
+++ b/src/token_tally/soc2_monitor.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Sequence
+from urllib.request import urlopen
+from urllib.error import URLError
+
+from .audit import AuditLog
+
+
+def verify_audit_log(db_path: str) -> bool:
+    """Return ``True`` if the audit log hash chain is intact."""
+    log = AuditLog(db_path)
+    return log.verify_chain()
+
+
+def check_health(url: str, timeout: float = 5.0) -> bool:
+    """Return ``True`` if ``url`` responds with HTTP 200."""
+    try:
+        with urlopen(url, timeout=timeout) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def run(
+    db_path: str,
+    health_urls: Sequence[str],
+    interval: int = 300,
+    iterations: int | None = None,
+) -> None:
+    """Periodically verify audit log and service health."""
+    count = 0
+    while True:
+        if not verify_audit_log(db_path):
+            print("Audit log verification failed", flush=True)
+        for url in health_urls:
+            if not check_health(url):
+                print(f"Health check failed for {url}", flush=True)
+        count += 1
+        if iterations is not None and count >= iterations:
+            break
+        time.sleep(interval)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="SOC2 monitoring loop")
+    parser.add_argument("db_path", help="Path to audit log database")
+    parser.add_argument("health_urls", nargs="*", help="URLs to check")
+    parser.add_argument(
+        "--interval", type=int, default=300, help="Seconds between checks"
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    run(args.db_path, args.health_urls, args.interval)
+
+
+if __name__ == "__main__":
+    main(None)
+
+__all__ = ["verify_audit_log", "check_health", "run", "main"]

--- a/tests/test_soc2_monitor.py
+++ b/tests/test_soc2_monitor.py
@@ -1,0 +1,68 @@
+import sys
+import pathlib
+import sqlite3
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from token_tally.audit import AuditLog
+from token_tally.soc2_monitor import verify_audit_log, check_health, run
+
+
+class _OKHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        self.send_response(200)
+        self.end_headers()
+
+
+class _FailHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        self.send_response(500)
+        self.end_headers()
+
+
+def _start_server(handler) -> tuple[HTTPServer, threading.Thread, int]:
+    server = HTTPServer(("localhost", 0), handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return server, thread, server.server_address[1]
+
+
+def test_verify_audit_log(tmp_path):
+    db = tmp_path / "audit.db"
+    log = AuditLog(str(db))
+    log.add_event("e1", "c1", "foo", 1)
+    log.add_event("e2", "c1", "bar", 2)
+    assert verify_audit_log(str(db))
+
+    with sqlite3.connect(db) as conn:
+        conn.execute("UPDATE audit_events SET prev_hash = 'bad' WHERE event_id = 'e2'")
+        conn.commit()
+
+    assert not verify_audit_log(str(db))
+
+
+def test_check_health_ok_and_fail():
+    server, thread, port = _start_server(_OKHandler)
+    try:
+        assert check_health(f"http://localhost:{port}")
+    finally:
+        server.shutdown()
+        thread.join()
+
+    # After shutdown the check should fail
+    assert not check_health(f"http://localhost:{port}")
+
+
+def test_run_single_iteration(tmp_path):
+    db = tmp_path / "audit.db"
+    log = AuditLog(str(db))
+    log.add_event("e1", "c1", "foo", 1)
+    server, thread, port = _start_server(_OKHandler)
+    try:
+        run(str(db), [f"http://localhost:{port}"], interval=0, iterations=1)
+    finally:
+        server.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- add `soc2_monitor` helper to validate audit logs and check service health
- document cron job usage in README
- test SOC2 monitoring behaviour

## Testing
- `pytest -q`