### PR TITLE
Implement region-aware forecasting

### DIFF
--- a/src/token_tally/forecast.py
+++ b/src/token_tally/forecast.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import List
+from typing import List, Optional
 
 from .usage_ledger import UsageLedger
 
@@ -32,7 +32,14 @@ def arima_forecast(series: List[float]) -> float:
     return series[-1] + forecast_diff
 
 
-def forecast_next_hour(ledger: UsageLedger, hours: int = 24) -> float:
-    """Return the forecasted spend for the next hour."""
-    totals = ledger.get_hourly_totals(hours)
+def forecast_next_hour(
+    ledger: UsageLedger, hours: int = 24, region: Optional[str] = None
+) -> float:
+    """Return the forecasted spend for the next hour.
+
+    If ``region`` is provided and the underlying ledger supports it, only events
+    for that region are considered. This keeps backwards compatibility with
+    ledgers that lack a ``region`` column by simply ignoring the parameter.
+    """
+    totals = ledger.get_hourly_totals(hours, region=region)
     return arima_forecast(totals)

--- a/src/token_tally/forecast_cli.py
+++ b/src/token_tally/forecast_cli.py
@@ -8,9 +8,10 @@ from .usage_ledger import UsageLedger
 def main(argv: Iterable[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Forecast next hour spend")
     parser.add_argument("db_path", help="Path to ledger.db")
+    parser.add_argument("--region", help="Region name to forecast")
     args = parser.parse_args(list(argv) if argv is not None else None)
     ledger = UsageLedger(args.db_path)
-    prediction = forecast_next_hour(ledger)
+    prediction = forecast_next_hour(ledger, region=args.region)
     print(prediction)
 
 

--- a/src/token_tally/usage_ledger.py
+++ b/src/token_tally/usage_ledger.py
@@ -136,16 +136,26 @@ class UsageLedger:
                 self.producer.send(self.kafka_topic, asdict(event))
                 self.producer.flush()
 
-    def get_hourly_totals(self, hours: int) -> list[float]:
-        """Return spend totals for the last ``hours`` hours."""
+    def get_hourly_totals(
+        self, hours: int, region: Optional[str] = None
+    ) -> list[float]:
+        """Return spend totals for the last ``hours`` hours.
+
+        When ``region`` is provided and the ``usage_events`` table includes a
+        ``region`` column, totals are filtered accordingly.
+        """
         end = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
         start = end - timedelta(hours=hours)
         totals = [0.0 for _ in range(hours)]
         with sqlite3.connect(self.db_path) as conn:
-            cur = conn.execute(
-                "SELECT ts, units, unit_cost_usd FROM usage_events WHERE ts >= ? AND ts < ?",
-                (start.isoformat(), end.isoformat()),
-            )
+            query = "SELECT ts, units, unit_cost_usd FROM usage_events WHERE ts >= ? AND ts < ?"
+            params: list[str] = [start.isoformat(), end.isoformat()]
+            if region is not None:
+                info = conn.execute("PRAGMA table_info(usage_events)").fetchall()
+                if any(col[1] == "region" for col in info):
+                    query += " AND region = ?"
+                    params.append(region)
+            cur = conn.execute(query, params)
             for ts_str, units, unit_cost in cur.fetchall():
                 ts = datetime.fromisoformat(ts_str)
                 idx = int((ts - start).total_seconds() // 3600)
@@ -263,17 +273,23 @@ class ClickHouseUsageLedger:
                 self.producer.send(self.kafka_topic, asdict(event))
                 self.producer.flush()
 
-    def get_hourly_totals(self, hours: int) -> list[float]:
+    def get_hourly_totals(
+        self, hours: int, region: Optional[str] = None
+    ) -> list[float]:
         end = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
         start = end - timedelta(hours=hours)
         totals = [0.0 for _ in range(hours)]
-        rows = self.client.execute(
-            """
-            SELECT ts, units, unit_cost_usd FROM usage_events
-            WHERE ts >= %(start)s AND ts < %(end)s
-            """,
-            {"start": start, "end": end},
-        )
+        query = "SELECT ts, units, unit_cost_usd FROM usage_events WHERE ts >= %(start)s AND ts < %(end)s"
+        params = {"start": start, "end": end}
+        if region is not None:
+            try:
+                desc = self.client.execute("DESCRIBE TABLE usage_events")
+            except Exception:
+                desc = []
+            if any(col[0] == "region" for col in desc):
+                query += " AND region = %(region)s"
+                params["region"] = region
+        rows = self.client.execute(query, params)
         for ts, units, unit_cost in rows:
             idx = int((ts - start).total_seconds() // 3600)
             if 0 <= idx < hours:

--- a/tests/test_forecast_cli.py
+++ b/tests/test_forecast_cli.py
@@ -39,3 +39,39 @@ def test_forecast_cli(tmp_path):
         check=True,
     )
     assert float(result.stdout.strip()) > 0.0
+
+
+def test_forecast_cli_region(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    ledger = UsageLedger(str(db_path))
+    now = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+    event = UsageEvent(
+        event_id="e1",
+        ts=now - timedelta(hours=1),
+        customer_id="cust",
+        provider="openai",
+        model="gpt",
+        metric_type="tokens",
+        units=10,
+        unit_cost_usd=0.5,
+    )
+    ledger.add_event(event)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC_DIR)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "token_tally.forecast_cli",
+            str(db_path),
+            "--region",
+            "us",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+    assert float(result.stdout.strip()) > 0.0


### PR DESCRIPTION
## Summary
- allow `forecast_next_hour` to filter by region
- plumb region option through `forecast_cli`
- extend ledger APIs to support optional region filtering
- test CLI with `--region` flag

## Testing
- `black src/token_tally/forecast.py src/token_tally/forecast_cli.py src/token_tally/usage_ledger.py tests/test_forecast_cli.py`
- `pytest -q`