### PR TITLE
Add business_unit column to ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,13 @@ python -m token_tally.stripe_webhook whsec_test --db-path ledger.db --port 9000
 ```
 
 Configure Stripe to send webhooks to `http://localhost:9000/webhook`.
+
+## Upgrading
+If you are migrating from a previous version of TokenTally, the ledger schema
+now includes a `business_unit` column on both the `usage_events` and `invoices`
+tables. Existing databases can be updated with:
+
+```sql
+ALTER TABLE usage_events ADD COLUMN business_unit TEXT NOT NULL DEFAULT '';
+ALTER TABLE invoices ADD COLUMN business_unit TEXT NOT NULL DEFAULT '';
+```

--- a/src/token_tally/tests/test_billing.py
+++ b/src/token_tally/tests/test_billing.py
@@ -17,7 +17,9 @@ class DummyClient(StripeUsageClient):
 def test_sync_usage_events(tmp_path):
     db = tmp_path / "ledger.db"
     ledger = Ledger(str(db))
-    ledger.add_usage_event("e1", "cust", "item1", 5, 1.0, "2024-05")
+    ledger.add_usage_event(
+        "e1", "cust", "item1", 5, 1.0, "2024-05", business_unit="sales"
+    )
     service = BillingService("sk_test", ledger)
     service.client = DummyClient()
     count = service.sync_usage_events()
@@ -29,8 +31,12 @@ def test_sync_usage_events(tmp_path):
 def test_consolidate_invoices(tmp_path):
     db = tmp_path / "ledger.db"
     ledger = Ledger(str(db))
-    ledger.add_usage_event("e1", "cust", "item1", 10, 2.0, "2024-05")
-    ledger.add_usage_event("e2", "cust", "item1", -2, 2.0, "2024-05")
+    ledger.add_usage_event(
+        "e1", "cust", "item1", 10, 2.0, "2024-05", business_unit="sales"
+    )
+    ledger.add_usage_event(
+        "e2", "cust", "item1", -2, 2.0, "2024-05", business_unit="sales"
+    )
     service = BillingService("sk_test", ledger)
     service.client = DummyClient()
     invoices = service.consolidate_invoices("2024-05")
@@ -40,7 +46,9 @@ def test_consolidate_invoices(tmp_path):
 def test_consolidate_invoices_fx(tmp_path, monkeypatch):
     db = tmp_path / "ledger.db"
     ledger = Ledger(str(db))
-    ledger.add_usage_event("e1", "cust", "item1", 10, 2.0, "2024-05")
+    ledger.add_usage_event(
+        "e1", "cust", "item1", 10, 2.0, "2024-05", business_unit="sales"
+    )
     service = BillingService("sk_test", ledger)
     service.client = DummyClient()
 


### PR DESCRIPTION
## Summary
- add `business_unit` field to usage_events and invoices tables
- insert and select business_unit in ledger helpers
- update billing tests
- document migration notes

## Testing
- `pytest -q`