### PR TITLE
Add SOC 2 Type I plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Stripe Invoice → Customer
 | Continuous monitoring in place| Q2 2026   |
 | Type II report                | Q4 2026   |
 
+For a detailed breakdown of the controls and timeline leading up to the Type I audit, see [docs/soc2_type1_plan.md](docs/soc2_type1_plan.md).
+
 ### Data residency options
 
 TokenTally runs in US-East by default. Enterprise customers may pin all data processing to the EU region or deploy the gateway inside their own Kubernetes clusters using the Helm chart under `helm/token-tally`.

--- a/docs/soc2_type1_plan.md
+++ b/docs/soc2_type1_plan.md
@@ -1,0 +1,30 @@
+# SOC 2 Type I Compliance Plan
+
+This document outlines the high-level controls and milestones required to obtain a SOC 2 Type I report. The plan assumes work begins in July 2025.
+
+## Controls
+
+The following control areas must be implemented and documented:
+
+1. **Security policies** – establish information security, incident response and acceptable use policies. Publish them internally and require annual acknowledgement.
+2. **Access management** – enforce single sign-on, multi-factor authentication and least privilege across all production systems.
+3. **Change management** – document code review procedures and maintain audit trails for configuration changes.
+4. **Vendor management** – track third-party services, review their SOC reports and maintain data processing agreements.
+5. **Logging and monitoring** – centralise application logs, enable alerting for suspicious activity and review logs weekly.
+6. **Backup and recovery** – run daily database backups and quarterly restore tests.
+7. **Risk assessment** – perform and document an annual risk assessment covering all services and data flows.
+
+## Timeline
+
+| Month | Activity |
+| ----- | -------- |
+| **Jul 2025** | Kick off with policy drafting and risk assessment. |
+| **Aug 2025** | Finalise policies, onboard compliance tooling. |
+| **Sep 2025** | Implement access controls and logging configuration. |
+| **Oct 2025** | Complete vendor reviews and change management processes. |
+| **Nov 2025** | Conduct internal readiness assessment with CISO. |
+| **Dec 2025** | Engage audit firm for Type I examination. |
+| **Jan 2026** | Provide evidence and walkthroughs to auditors. |
+| **Feb 2026** | Receive and review the Type I report. |
+
+Meeting these milestones positions TokenTally to achieve a SOC 2 Type I report by February 2026 and sets the foundation for Type II monitoring.


### PR DESCRIPTION
## Summary
- document SOC 2 Type I compliance plan
- link the plan from the README

## Testing
- `pytest -q`
- `npm run build` *(fails: `next` not found)*