### PR TITLE
Implement route_provider helper

### DIFF
--- a/src/token_tally/__init__.py
+++ b/src/token_tally/__init__.py
@@ -43,6 +43,5 @@ __all__ = [
     "send_webhook_message",
     "route_request",
     "route_provider",
-
     "suggest_commitments",
 ]

--- a/src/token_tally/billing.py
+++ b/src/token_tally/billing.py
@@ -116,7 +116,7 @@ class BillingService:
             except Exception:
                 pass
 
-              invoices.append(
+            invoices.append(
                 {"invoice_id": invoice_id, "total": amt, "credit": credit_amount}
             )
         return invoices

--- a/src/token_tally/cost_router.py
+++ b/src/token_tally/cost_router.py
@@ -7,6 +7,7 @@ from typing import Iterable, Optional, Dict, Any
 from .markup import get_effective_markup
 from .fx_rates import get_rates
 from .fx import convert
+from .gpu_arbitrage import choose_best_gpu_host
 
 
 @dataclass
@@ -97,3 +98,14 @@ def route_request(
         result.update(best.extra)
     return result
 
+
+def route_provider(provider: str) -> str:
+    """Return chosen provider name or host.
+
+    If ``provider`` is ``"local"`` choose the best GPU host dynamically.
+    ``provider`` is returned unchanged otherwise.
+    """
+
+    if provider == "local":
+        return choose_best_gpu_host()
+    return provider

--- a/tests/test_usage_export.py
+++ b/tests/test_usage_export.py
@@ -87,7 +87,8 @@ def test_snowflake_export_cli(tmp_path, monkeypatch):
     assert rows[0][0] == "cust1"
     assert rows[1][0] == "cust2"
 
-    def test_bigquery_export(monkeypatch, tmp_path):
+
+def test_bigquery_export(monkeypatch, tmp_path):
     db_path = tmp_path / "ledger.db"
     ledger = Ledger(str(db_path))
     ledger.add_usage_event("e1", "cust", "feat", 3, 0.5, "2024-05")


### PR DESCRIPTION
## Summary
- define `route_provider` in `cost_router`
- keep API export list stable
- fix indentation in billing service and tests

## Testing
- `black src/token_tally/cost_router.py src/token_tally/__init__.py src/token_tally/billing.py tests/test_usage_export.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b9779c9dc83328d7a0d54ff441b2e